### PR TITLE
fix: 修复万象炉AE任务材料丢失/复制、能耗结算与超大批量（512M级）合成失败问题

### DIFF
--- a/src/main/java/com/sorrowmist/useless/compat/EapCompat.java
+++ b/src/main/java/com/sorrowmist/useless/compat/EapCompat.java
@@ -89,7 +89,7 @@ public final class EapCompat {
             long scaledAmt = outputs.getFirst().amount();
             if (origAmt > 0) {
                 long mul = scaledAmt / origAmt;
-                if (mul > 0) return (int) mul;
+                if (mul > 0) return (int) Math.min(mul, Integer.MAX_VALUE);
             }
         }
         return 1;

--- a/src/main/java/com/sorrowmist/useless/content/blockentities/AdvancedAlloyFurnaceBlockEntity.java
+++ b/src/main/java/com/sorrowmist/useless/content/blockentities/AdvancedAlloyFurnaceBlockEntity.java
@@ -327,6 +327,7 @@ public class AdvancedAlloyFurnaceBlockEntity extends AEBaseBlockEntity implement
 
         entity.aeManager.flushAEBatches();
         entity.aeManager.tickAETasks();
+        entity.aeManager.tickUnreturnedInputs();
 
         // 每tick尝试自动输入输出物品和流体
         entity.autoOutputTickCounter++;
@@ -831,6 +832,11 @@ public class AdvancedAlloyFurnaceBlockEntity extends AEBaseBlockEntity implement
         this.aeManager.cancelAllTasks();
     }
 
+    @Override
+    public void stashUnreturnedInput(AEKey key, long amount) {
+        this.aeManager.stashUnreturnedInput(key, amount);
+    }
+
     public IEnergyStorage getEnergyStorage() {
         return this.energyManager;
     }
@@ -1237,28 +1243,6 @@ public class AdvancedAlloyFurnaceBlockEntity extends AEBaseBlockEntity implement
                 this.outputFluidTanks,
                 FLUID_TANK_COUNT
         );
-    }
-
-    private FurnaceOutputPort.AeOutput createAeOutputPort() {
-        return new FurnaceOutputPort.AeOutput() {
-            @Override
-            public long insertItem(ItemStack stack) {
-                if (!AdvancedAlloyFurnaceBlockEntity.this.isReturnOutputToAe()) return 0;
-                return AdvancedAlloyFurnaceBlockEntity.this.tryOutputToAE(stack);
-            }
-
-            @Override
-            public long insertFluid(FluidStack stack) {
-                if (!AdvancedAlloyFurnaceBlockEntity.this.isReturnOutputToAe()) return 0;
-                return AdvancedAlloyFurnaceBlockEntity.this.tryOutputFluidToAE(stack);
-            }
-
-            @Override
-            public long insertKey(AEKey key, long amount) {
-                if (!AdvancedAlloyFurnaceBlockEntity.this.isReturnOutputToAe()) return 0;
-                return AdvancedAlloyFurnaceBlockEntity.this.tryOutputKeyToAE(key, amount);
-            }
-        };
     }
 
     private void resetProgress() {

--- a/src/main/java/com/sorrowmist/useless/content/blocks/AdvancedAlloyFurnaceBlock.java
+++ b/src/main/java/com/sorrowmist/useless/content/blocks/AdvancedAlloyFurnaceBlock.java
@@ -112,6 +112,11 @@ public class AdvancedAlloyFurnaceBlock extends Block implements EntityBlock {
             if (blockEntity instanceof AdvancedAlloyFurnaceBlockEntity furnace) {
                 // 掉落物品（不包括容器内的物品，它们会保存在方块物品中）
                 // 注意：使用精准采集时，物品会通过 getDrops 保存到方块物品中
+                // AE 任务数据不随掉落物保存，必须在此返还材料：
+                // onRemove 先于 setRemoved 执行，此时 AE 节点仍然存活，材料能真正写回网络
+                if (!level.isClientSide) {
+                    furnace.cancelAllAETasks();
+                }
             }
         }
         super.onRemove(state, level, pos, newState, isMoving);

--- a/src/main/java/com/sorrowmist/useless/content/machines/advanced_alloy_furnace/ae/AdvancedAlloyFurnaceAeManager.java
+++ b/src/main/java/com/sorrowmist/useless/content/machines/advanced_alloy_furnace/ae/AdvancedAlloyFurnaceAeManager.java
@@ -37,6 +37,7 @@ import java.util.concurrent.locks.ReentrantLock;
 public final class AdvancedAlloyFurnaceAeManager {
     private static final int MAX_CONCURRENT_TASKS = 4;
     private static final int BATCH_RIPE_TICKS = 10;
+    private static final int UNRETURNED_RETRY_TICKS = 20;
 
     private final AdvancedAlloyFurnaceBlockEntity owner;
     private final ConcurrentHashMap<Integer, CraftingTask> activeTasks = new ConcurrentHashMap<>();
@@ -49,6 +50,9 @@ public final class AdvancedAlloyFurnaceAeManager {
     private final AtomicInteger activeAETaskCount = new AtomicInteger(0);
     private final AtomicInteger totalAEProgress = new AtomicInteger(0);
     private final AtomicInteger totalAEMaxProgress = new AtomicInteger(0);
+    // 返还失败的输入暂存（防丢失），逐 tick 重试写回 AE 网络；仅服务端主线程访问
+    private final List<GenericStack> unreturnedInputs = new ArrayList<>();
+    private int unreturnedRetryTimer = 0;
     private int patternPriority = 0;
     private int nextTaskId = 0;
     // 延迟加载的任务数据（loadTag 时 level 尚不可用，需推迟到首 tick 解码样板）
@@ -59,8 +63,14 @@ public final class AdvancedAlloyFurnaceAeManager {
         this.owner = owner;
     }
 
+    /**
+     * 方块实体被移除时的清理。
+     * 注意：不做取消返还 —— 任务与批次已随 NBT 持久化（区块卸载后会恢复），
+     * 在这里返还会造成卸载复制；且 setRemoved 时 AE 节点已销毁，材料无法写回网络。
+     * 主动取消只有两个入口：玩家在 GUI 点取消（AECancelPacket），以及方块被真正破坏时
+     * AdvancedAlloyFurnaceBlock.onRemove 在节点销毁前调用。
+     */
     public void shutdown() {
-        this.cancelAllTasks();
     }
 
     public void cancelAllTasks() {
@@ -71,10 +81,61 @@ public final class AdvancedAlloyFurnaceAeManager {
         this.totalAEProgress.set(0);
         this.totalAEMaxProgress.set(0);
         this.aeTaskProgressMap.clear();
+
+        // 待启动批次的输入尚未转为任务，同样需要返还，否则材料会随 clear() 丢失
+        List<KeyCounter[]> pendingInputs = new ArrayList<>();
         synchronized (this.aePendingBatches) {
+            for (PendingAEBatch batch : this.aePendingBatches.values()) {
+                pendingInputs.addAll(batch.drain());
+            }
             this.aePendingBatches.clear();
         }
+        CraftingTask.returnInputsToAE(pendingInputs, this.owner);
+
         this.owner.markChanged();
+        // 全部清空后主动同步一次，否则客户端会残留已取消的排队任务
+        this.sendAETaskProgressToClients();
+    }
+
+    // ==================== 未返还输入暂存 ====================
+
+    /** 暂存返还失败的输入（如 AE 不可达时的化学品/流体），逐 tick 重试写回网络 */
+    public void stashUnreturnedInput(AEKey key, long amount) {
+        if (key == null || amount <= 0) {
+            return;
+        }
+        this.unreturnedInputs.add(new GenericStack(key, amount));
+        this.owner.markChanged();
+    }
+
+    /** 定期把暂存的未返还输入重试写回 AE 网络 */
+    public void tickUnreturnedInputs() {
+        if (this.unreturnedInputs.isEmpty()) {
+            return;
+        }
+        if (++this.unreturnedRetryTimer < UNRETURNED_RETRY_TICKS) {
+            return;
+        }
+        this.unreturnedRetryTimer = 0;
+
+        boolean changed = false;
+        var it = this.unreturnedInputs.listIterator();
+        while (it.hasNext()) {
+            GenericStack gs = it.next();
+            long inserted = this.owner.tryOutputKeyToAE(gs.what(), gs.amount());
+            if (inserted <= 0) {
+                continue;
+            }
+            changed = true;
+            if (inserted >= gs.amount()) {
+                it.remove();
+            } else {
+                it.set(new GenericStack(gs.what(), gs.amount() - inserted));
+            }
+        }
+        if (changed) {
+            this.owner.markChanged();
+        }
     }
 
     // ==================== 持久化 ====================
@@ -99,6 +160,12 @@ public final class AdvancedAlloyFurnaceAeManager {
             }
         }
         tag.put("PendingBatches", pendingTag);
+
+        ListTag unreturnedTag = new ListTag();
+        for (GenericStack gs : this.unreturnedInputs) {
+            unreturnedTag.add(GenericStack.writeTag(registries, gs));
+        }
+        tag.put("UnreturnedInputs", unreturnedTag);
         tag.putInt("NextTaskId", this.nextTaskId);
     }
 
@@ -145,6 +212,14 @@ public final class AdvancedAlloyFurnaceAeManager {
                 if (batch != null && batch.pattern != null) {
                     this.aePendingBatches.put(PatternKey.of(batch.pattern), batch);
                 }
+            }
+        }
+
+        ListTag unreturnedTag = tag.getList("UnreturnedInputs", Tag.TAG_COMPOUND);
+        for (int i = 0; i < unreturnedTag.size(); i++) {
+            GenericStack gs = GenericStack.readTag(registries, unreturnedTag.getCompound(i));
+            if (gs != null) {
+                this.unreturnedInputs.add(gs);
             }
         }
     }
@@ -458,10 +533,10 @@ public final class AdvancedAlloyFurnaceAeManager {
         KeyCounter[] merged = this.mergeKeyCounters(allInputs);
 
         int taskId = this.nextTaskId++;
-        // EAP 翻倍：用原始样板 + 缩放后的 craftCount
+        // EAP 翻倍：用原始样板 + 缩放后的 craftCount（long 运算防溢出，按 int 上限饱和）
         IPatternDetails taskPattern = EapCompat.unwrap(batch.pattern);
         int multiplier = EapCompat.getMultiplier(batch.pattern);
-        int totalCrafts = allInputs.size() * multiplier;
+        int totalCrafts = (int) Math.min((long) allInputs.size() * multiplier, Integer.MAX_VALUE);
 
         CraftingTask task = new CraftingTask(taskId, taskPattern, merged, totalCrafts, this.owner);
         if (!task.canStartNow()) {
@@ -584,10 +659,10 @@ public final class AdvancedAlloyFurnaceAeManager {
             this.statusDetail = statusDetail;
         }
 
-        // 更新合成次数和最终产物总数（用于任务合并）
+        // 更新合成次数和最终产物总数（用于任务合并；long 运算防 512M 级溢出）
         public void updateCraftCount(int newCraftCount) {
             this.craftCount = newCraftCount;
-            this.totalOutputCount = newCraftCount * outputCount;
+            this.totalOutputCount = (int) Math.min((long) newCraftCount * outputCount, Integer.MAX_VALUE);
         }
     }
 
@@ -603,8 +678,10 @@ public final class AdvancedAlloyFurnaceAeManager {
         }
 
         void add(KeyCounter[] input) {
+            // 不重置 ripeTimer：成熟计时从批次创建（或重排）起算。
+            // 若每次推送都重置，AE CPU 对超大请求持续推送时批次永远不会成熟，
+            // 任务迟迟不启动，表现为“一直不合成”。
             this.allInputs.add(input);
-            this.ripeTimer = BATCH_RIPE_TICKS;
         }
 
         List<KeyCounter[]> drain() {

--- a/src/main/java/com/sorrowmist/useless/content/machines/advanced_alloy_furnace/ae/CraftingTask.java
+++ b/src/main/java/com/sorrowmist/useless/content/machines/advanced_alloy_furnace/ae/CraftingTask.java
@@ -18,6 +18,7 @@ import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
+import net.minecraft.world.Containers;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.neoforged.neoforge.fluids.FluidStack;
@@ -40,6 +41,13 @@ public class CraftingTask {
     private final List<FluidStack> taskInputFluids = new ArrayList<>();
     private final List<OutputKey> taskInputKeys = new ArrayList<>();
     private final List<CraftingSubTask> queuedSubTasks = new ArrayList<>();
+    // 待输出缓冲：产物先进缓冲，由 flushPendingOutputs 逐 tick 写出，写不下时保留重试，避免静默丢失
+    private final List<ItemStack> pendingOutputItems = new ArrayList<>();
+    private final List<FluidStack> pendingOutputFluids = new ArrayList<>();
+    private final List<OutputKey> pendingOutputKeys = new ArrayList<>();
+    private boolean awaitingOutputFlush = false;
+    // 当前子任务已扣除的能量，用于完成结算（与本体 settleCompletionEnergy 语义对齐）
+    private long accumulatedEnergy = 0;
     private int craftCount = 1;
     private int displayedCraftCount = 1;
     private boolean cancelled = false;
@@ -66,7 +74,7 @@ public class CraftingTask {
         this.context = context;
         this.craftCount = Math.max(1, totalCrafts);
         this.displayedCraftCount = this.craftCount;
-        this.storeInputMaterials(inputHolder, this.taskInputItems, this.taskInputFluids, this.taskInputKeys);
+        storeInputMaterials(inputHolder, this.taskInputItems, this.taskInputFluids, this.taskInputKeys);
     }
 
     /** 从一个拆分出的子任务构造独立任务（用于空闲线程再分配） */
@@ -104,7 +112,18 @@ public class CraftingTask {
         if (processingComplete || cancelled) {
             return false;
         }
-        queuedSubTasks.add(createMergedSubTask(allInputs));
+        CraftingSubTask merged = createMergedSubTask(allInputs);
+        if (queuedSubTasks.isEmpty()) {
+            queuedSubTasks.add(merged);
+        } else {
+            // 并入队尾尚未启动的子任务，减少批次数（每个子任务独立收一份结算能量）
+            CraftingSubTask last = queuedSubTasks.getLast();
+            last.items.addAll(merged.items);
+            last.fluids.addAll(merged.fluids);
+            last.keys.addAll(merged.keys);
+            int combined = (int) Math.min((long) last.craftCount + merged.craftCount, Integer.MAX_VALUE);
+            queuedSubTasks.set(queuedSubTasks.size() - 1, new CraftingSubTask(last.items, last.fluids, last.keys, combined));
+        }
         updateDisplayedCraftCount();
         updateTaskProgressTotals();
         context.markChanged();
@@ -172,7 +191,7 @@ public class CraftingTask {
         return new CraftingSubTask(items, fluids, keys, Math.max(1, allInputs.size()));
     }
 
-    private void storeInputMaterials(KeyCounter[] counters, List<ItemStack> items, List<FluidStack> fluids, List<OutputKey> keys) {
+    private static void storeInputMaterials(KeyCounter[] counters, List<ItemStack> items, List<FluidStack> fluids, List<OutputKey> keys) {
         if (counters == null) return;
 
         for (KeyCounter counter : counters) {
@@ -182,12 +201,22 @@ public class CraftingTask {
                 AEKey key = entry.getKey();
                 long amount = entry.getLongValue();
 
+                // ItemStack/FluidStack 数量是 int：512M 级请求直接强转会溢出为负，
+                // 导致材料变空、配方匹配失败。超出部分按 int 上限分块存放。
                 if (key instanceof AEItemKey itemKey) {
-                    ItemStack stack = itemKey.toStack((int) amount);
-                    items.add(stack);
+                    long remaining = amount;
+                    while (remaining > 0) {
+                        int chunk = (int) Math.min(remaining, Integer.MAX_VALUE);
+                        items.add(itemKey.toStack(chunk));
+                        remaining -= chunk;
+                    }
                 } else if (key instanceof AEFluidKey fluidKey) {
-                    FluidStack stack = new FluidStack(fluidKey.getFluid(), (int) amount);
-                    fluids.add(stack);
+                    long remaining = amount;
+                    while (remaining > 0) {
+                        int chunk = (int) Math.min(remaining, Integer.MAX_VALUE);
+                        fluids.add(new FluidStack(fluidKey.getFluid(), chunk));
+                        remaining -= chunk;
+                    }
                 } else {
                     keys.add(new OutputKey(key, amount));
                 }
@@ -303,21 +332,76 @@ public class CraftingTask {
             fluidsToReturn.addAll(subTask.fluids);
             keysToReturn.addAll(subTask.keys);
         }
+        // 已结算但尚未写出的产物同样不能丢，随取消一并返还
+        itemsToReturn.addAll(pendingOutputItems);
+        fluidsToReturn.addAll(pendingOutputFluids);
+        keysToReturn.addAll(pendingOutputKeys);
+        pendingOutputItems.clear();
+        pendingOutputFluids.clear();
+        pendingOutputKeys.clear();
+        awaitingOutputFlush = false;
         taskInputItems.clear();
         taskInputFluids.clear();
         taskInputKeys.clear();
         queuedSubTasks.clear();
 
-        for (OutputKey keyToReturn : keysToReturn) {
-            FurnaceOutputPort.outputKey(keyToReturn.key, keyToReturn.amount, createAeOutputPort());
+        returnMaterials(context, itemsToReturn, fluidsToReturn, keysToReturn);
+    }
+
+    /** 返还尚未转为任务的 AE 原始输入（待启动批次取消时使用） */
+    public static void returnInputsToAE(List<KeyCounter[]> allInputs, CraftingTaskContext context) {
+        List<ItemStack> items = new ArrayList<>();
+        List<FluidStack> fluids = new ArrayList<>();
+        List<OutputKey> keys = new ArrayList<>();
+        for (KeyCounter[] counters : allInputs) {
+            storeInputMaterials(counters, items, fluids, keys);
+        }
+        returnMaterials(context, items, fluids, keys);
+    }
+
+    /**
+     * 返还材料，与产物一致地尊重“产物返回AE”开关：开关开启时优先写回 AE 网络，
+     * 其次本地输入槽/流体槽。任何路径都不允许静默丢失 ——
+     * 物品放不下时掉落到机器上方；流体最后尝试输出流体槽，仍有剩余则进暂存缓冲重试；
+     * key 类材料（如化学品）没有本地槽位可回退，无视开关直接尝试 AE，失败部分进暂存缓冲。
+     */
+    private static void returnMaterials(CraftingTaskContext context, List<ItemStack> items, List<FluidStack> fluids, List<OutputKey> keys) {
+        Level level = context.getLevel();
+        if (level == null || level.isClientSide) return;
+        if (items.isEmpty() && fluids.isEmpty() && keys.isEmpty()) return;
+
+        FurnaceOutputPort.AeOutput port = context.createAeOutputPort();
+
+        for (OutputKey keyToReturn : keys) {
+            long inserted = context.tryOutputKeyToAE(keyToReturn.key, keyToReturn.amount);
+            long remaining = keyToReturn.amount - inserted;
+            if (remaining > 0) {
+                context.stashUnreturnedInput(keyToReturn.key, remaining);
+            }
         }
 
-        for (ItemStack stack : itemsToReturn) {
-            FurnaceOutputPort.outputItem(stack, createAeOutputPort(), context.getItemHandler(), context.getInputSlotsStart(), context.getInputSlotsCount());
+        for (ItemStack stack : items) {
+            ItemStack leftover = FurnaceOutputPort.outputItemWithRemainder(stack, port,
+                    context.getItemHandler(), context.getInputSlotsStart(), context.getInputSlotsCount());
+            if (!leftover.isEmpty()) {
+                var pos = context.getBlockPos();
+                Containers.dropItemStack(level, pos.getX() + 0.5, pos.getY() + 1.0, pos.getZ() + 0.5, leftover);
+            }
         }
 
-        for (FluidStack fluidStack : fluidsToReturn) {
-            FurnaceOutputPort.outputFluid(fluidStack, createAeOutputPort(), context.getInputFluidTanks(), context.getFluidTankCount());
+        for (FluidStack fluidStack : fluids) {
+            FluidStack leftover = FurnaceOutputPort.outputFluidWithRemainder(fluidStack, port,
+                    context.getInputFluidTanks(), context.getFluidTankCount());
+            if (!leftover.isEmpty()) {
+                leftover = FurnaceOutputPort.outputFluidWithRemainder(leftover, port,
+                        context.getOutputFluidTanks(), context.getFluidTankCount());
+            }
+            if (!leftover.isEmpty()) {
+                AEFluidKey fluidKey = AEFluidKey.of(leftover);
+                if (fluidKey != null) {
+                    context.stashUnreturnedInput(fluidKey, leftover.getAmount());
+                }
+            }
         }
         context.markChanged();
     }
@@ -343,44 +427,106 @@ public class CraftingTask {
             return true;
         }
 
-        int batchIndex = baseProcessTime > 0 ? progress / baseProcessTime : 0;
-        int actualBatchParallel = batchIndex < batches - 1 ? maxParallel : lastBatchSize;
-        ResolvedCatalystEffect resolvedCatalystEffect = getCatalystEffect(findTaskRecipe());
-        AlloyFurnaceRecipeExecutor.TickResult tickResult = AlloyFurnaceRecipeExecutor.consumeTickEnergy(context.getEnergyManager(), baseEnergyPerTick, actualBatchParallel,
-                                                                                                        resolvedCatalystEffect
-        );
+        if (!awaitingOutputFlush) {
+            AdvancedAlloyFurnaceRecipe recipe = findTaskRecipe();
+            ResolvedCatalystEffect resolvedCatalystEffect = getCatalystEffect(recipe);
+            long energyTarget = getSubTaskEnergyTarget(recipe, resolvedCatalystEffect);
 
-        if (!tickResult.consumedEnergy()) {
-            return false;
-        }
+            if (progress < processTime) {
+                int batchIndex = baseProcessTime > 0 ? progress / baseProcessTime : 0;
+                int actualBatchParallel = batchIndex < batches - 1 ? maxParallel : lastBatchSize;
+                int tickEnergy = AlloyFurnaceRecipeExecutor.calculateTickEnergy(baseEnergyPerTick, actualBatchParallel, resolvedCatalystEffect);
+                // 每 tick 扣能以结算目标为上限，避免总额超出本体语义（有用锭=一份配方能量）
+                int required = (int) Math.min(tickEnergy, Math.max(0L, energyTarget - accumulatedEnergy));
+                if (required > 0) {
+                    if (!context.getEnergyManager().tryConsumeEnergy(required)) {
+                        return false;
+                    }
+                    accumulatedEnergy += required;
+                }
 
-        progress++;
-        context.getTotalAEProgressAtomic().incrementAndGet();
-        if (taskProgressRef != null) {
-            taskProgressRef.setProgress(progress);
-        }
-        context.markChanged();
+                progress++;
+                context.getTotalAEProgressAtomic().incrementAndGet();
+                if (taskProgressRef != null) {
+                    taskProgressRef.setProgress(progress);
+                }
+                context.markChanged();
 
-        progressUpdateCounter++;
-        if (progressUpdateCounter >= PROGRESS_SYNC_INTERVAL) {
-            context.sendAETaskProgressToClients();
-            progressUpdateCounter = 0;
-        }
+                progressUpdateCounter++;
+                if (progressUpdateCounter >= PROGRESS_SYNC_INTERVAL) {
+                    context.sendAETaskProgressToClients();
+                    progressUpdateCounter = 0;
+                }
 
-        if (progress >= processTime) {
-            completeCrafting(craftCount);
-            displayedCraftCount -= craftCount;
-            updateTaskProgressTotals();
+                if (progress < processTime) {
+                    return false;
+                }
+            }
+
+            // 完成结算：与本体 settleCompletionEnergy 语义对齐 ——
+            // 有用锭补足到一份配方能量，其余催化剂补足到 energy × craftCount
+            if (!settleSubTaskEnergy(energyTarget)) {
+                return false;
+            }
+
+            generatePendingOutputs(craftCount);
             taskInputItems.clear();
             taskInputFluids.clear();
             taskInputKeys.clear();
-            if (startNextSubTask()) {
-                context.markChanged();
-                context.sendAETaskProgressToClients();
-                return false;
-            }
-            finishTask();
+            awaitingOutputFlush = true;
+        }
+
+        // 产物写不下时保留在缓冲中逐 tick 重试，避免静默丢失
+        if (!flushPendingOutputs()) {
+            return false;
+        }
+        awaitingOutputFlush = false;
+
+        displayedCraftCount -= craftCount;
+        updateTaskProgressTotals();
+        if (startNextSubTask()) {
+            context.markChanged();
+            context.sendAETaskProgressToClients();
+            return false;
+        }
+        finishTask();
+        return true;
+    }
+
+    /**
+     * 当前子任务的能量结算目标，与本体 settleCompletionEnergy 的目标一致：
+     * 有用锭（不随并行倍增）时整个子任务只收一份配方能量；
+     * 其余催化剂按 energy × craftCount 收取完整份额。
+     */
+    private long getSubTaskEnergyTarget(@Nullable AdvancedAlloyFurnaceRecipe recipe, ResolvedCatalystEffect resolvedCatalystEffect) {
+        long recipeEnergy = recipe != null
+                ? Math.max(0, recipe.energy())
+                : (long) baseEnergyPerTick * Math.max(1, baseProcessTime);
+        return resolvedCatalystEffect.energyMultipliesWithParallel()
+                ? recipeEnergy * Math.max(1, craftCount)
+                : recipeEnergy;
+    }
+
+    /**
+     * 子任务完成时补扣能量到结算目标。能量不足时尽量扣取现有存量并保持等待，
+     * 直到补足为止（材料已消耗，无法像本体那样回退并行数）。
+     *
+     * @return 是否已补足到目标
+     */
+    private boolean settleSubTaskEnergy(long energyTarget) {
+        long deficit = energyTarget - accumulatedEnergy;
+        if (deficit <= 0) {
             return true;
+        }
+        int consumable = (int) Math.min(deficit, Integer.MAX_VALUE);
+        if (context.getEnergyManager().tryConsumeEnergy(consumable)) {
+            accumulatedEnergy += consumable;
+            return accumulatedEnergy >= energyTarget;
+        }
+        int available = context.getEnergyManager().getEnergyStored();
+        if (available > 0 && context.getEnergyManager().tryConsumeEnergy(available)) {
+            accumulatedEnergy += available;
+            context.markChanged();
         }
         return false;
     }
@@ -393,18 +539,7 @@ public class CraftingTask {
             return false;
         }
 
-        baseProcessTime = getRecipeProcessTime(recipe);
-        if (recipe != null && recipe.processTime() > 0) {
-            baseEnergyPerTick = Math.max(1, recipe.energy() / Math.max(1, recipe.processTime()));
-        } else {
-            baseEnergyPerTick = 200;
-        }
-
-        ResolvedCatalystEffect resolvedCatalystEffect = getCatalystEffect(recipe);
-        maxParallel = AlloyFurnaceParallelCalculator.calculateAeTaskParallel(context.getEnergyManager(), baseEnergyPerTick,
-                                                                             resolvedCatalystEffect
-        );
-
+        refreshCatalystLayout();
         recalculateBatchLayout();
 
         int outputCount = 1;
@@ -413,7 +548,7 @@ public class CraftingTask {
             outputCount = (int) output.amount();
         }
 
-        int totalOutputCount = displayedCraftCount * outputCount;
+        int totalOutputCount = (int) Math.min((long) displayedCraftCount * outputCount, Integer.MAX_VALUE);
         taskProgressRef = new AdvancedAlloyFurnaceAeManager.AETaskProgress(getProductName(), processTime, displayedCraftCount, totalOutputCount);
         this.waitingDetail = "";
         context.getAETaskProgressMap().put(taskId, taskProgressRef);
@@ -430,7 +565,7 @@ public class CraftingTask {
         if (pattern != null && !pattern.getOutputs().isEmpty()) {
             outputCount = (int) pattern.getOutputs().getFirst().amount();
         }
-        int totalOutputCount = displayedCraftCount * outputCount;
+        int totalOutputCount = (int) Math.min((long) displayedCraftCount * outputCount, Integer.MAX_VALUE);
         taskProgressRef = new AdvancedAlloyFurnaceAeManager.AETaskProgress(getProductName(), 0, 1, displayedCraftCount, totalOutputCount,
                 "gui.useless_mod.advanced_alloy_furnace.ae_task_status.waiting_mold", this.waitingDetail);
         context.getAETaskProgressMap().put(taskId, taskProgressRef);
@@ -439,9 +574,14 @@ public class CraftingTask {
     }
 
     private void recalculateBatchLayout() {
-        batches = (int) Math.ceil((double) craftCount / maxParallel);
-        processTime = Math.max(1, baseProcessTime * batches);
-        lastBatchSize = craftCount - maxParallel * (batches - 1);
+        // 全程 long 运算并按 int 上限饱和：512M 级 craftCount 下 int 乘法会溢出为负，
+        // 导致 processTime 被 Math.max 钳到 1、整批瞬间完成
+        long parallel = Math.max(1L, maxParallel);
+        long batchesLong = ((long) craftCount + parallel - 1) / parallel;
+        batches = (int) Math.min(batchesLong, Integer.MAX_VALUE);
+        long processTimeLong = (long) Math.max(1, baseProcessTime) * batches;
+        processTime = (int) Math.min(processTimeLong, Integer.MAX_VALUE);
+        lastBatchSize = (int) Math.max(1L, craftCount - parallel * (batches - 1L));
     }
 
     private void updateDisplayedCraftCount() {
@@ -476,6 +616,8 @@ public class CraftingTask {
         invalidateRecipeCache(); // 输入已变更，配方缓存失效
         craftCount = subTask.craftCount;
         progress = 0;
+        accumulatedEnergy = 0;
+        refreshCatalystLayout(); // 催化剂可能在执行期间被更换，按当前催化剂重算批次布局
         recalculateBatchLayout();
         if (progressRegistered) {
             context.getTotalAEMaxProgressAtomic().addAndGet(processTime);
@@ -493,6 +635,20 @@ public class CraftingTask {
         return CatalystEffectResolver.resolve(recipe, catalystStack, baseTime);
     }
 
+    /** 按当前催化剂重算时长、每 tick 能耗与并行上限（初始化及每个子任务启动时调用） */
+    private void refreshCatalystLayout() {
+        AdvancedAlloyFurnaceRecipe recipe = findTaskRecipe();
+        baseProcessTime = getRecipeProcessTime(recipe);
+        if (recipe != null && recipe.processTime() > 0) {
+            baseEnergyPerTick = Math.max(1, recipe.energy() / Math.max(1, recipe.processTime()));
+        } else {
+            baseEnergyPerTick = 200;
+        }
+        maxParallel = AlloyFurnaceParallelCalculator.calculateAeTaskParallel(context.getEnergyManager(), baseEnergyPerTick,
+                                                                             getCatalystEffect(recipe)
+        );
+    }
+
     private void finishTask() {
         processingComplete = true;
         if (progressRegistered) {
@@ -505,23 +661,32 @@ public class CraftingTask {
         context.sendAETaskProgressToClients();
     }
 
-    private void completeCrafting(int craftCount) {
+    /**
+     * 生成本批产物到待输出缓冲。数量全程 long 分块，防止 512M 级请求 int 溢出。
+     * 实际写出由 flushPendingOutputs 逐 tick 执行。
+     */
+    private void generatePendingOutputs(int craftCount) {
         if (context.getLevel() == null || context.getLevel().isClientSide) return;
 
         AdvancedAlloyFurnaceRecipe recipe = findTaskRecipe();
 
-        List<OutputFluid> outputFluids = new ArrayList<>();
-        List<OutputKey> outputKeys = new ArrayList<>();
-
         for (var output : pattern.getOutputs()) {
             if (output.what() instanceof AEItemKey itemKey) {
-                ItemStack outputStack = itemKey.toStack((int) (output.amount() * craftCount));
-                FurnaceOutputPort.outputItem(outputStack, createAeOutputPort(), context.getItemHandler(), context.getOutputSlotsStart(), context.getOutputSlotsCount());
+                long remaining = output.amount() * (long) craftCount;
+                while (remaining > 0) {
+                    int chunk = (int) Math.min(remaining, Integer.MAX_VALUE);
+                    pendingOutputItems.add(itemKey.toStack(chunk));
+                    remaining -= chunk;
+                }
             } else if (output.what() instanceof AEFluidKey fluidKey) {
-                FluidStack outputFluid = new FluidStack(fluidKey.getFluid(), (int) (output.amount() * craftCount));
-                outputFluids.add(new OutputFluid(outputFluid));
+                long remaining = output.amount() * (long) craftCount;
+                while (remaining > 0) {
+                    int chunk = (int) Math.min(remaining, Integer.MAX_VALUE);
+                    pendingOutputFluids.add(new FluidStack(fluidKey.getFluid(), chunk));
+                    remaining -= chunk;
+                }
             } else {
-                outputKeys.add(new OutputKey(output.what(), output.amount() * craftCount));
+                pendingOutputKeys.add(new OutputKey(output.what(), output.amount() * craftCount));
             }
         }
 
@@ -536,41 +701,57 @@ public class CraftingTask {
                     }
                 }
                 if (!alreadyInPattern) {
-                    outputKeys.add(new OutputKey(keyOutput.what(), keyOutput.amount() * craftCount));
+                    pendingOutputKeys.add(new OutputKey(keyOutput.what(), keyOutput.amount() * craftCount));
                 }
             }
-        }
-
-        for (OutputFluid outputFluid : outputFluids) {
-            FurnaceOutputPort.outputFluid(outputFluid.stack, createAeOutputPort(), context.getOutputFluidTanks(), context.getFluidTankCount());
-        }
-
-        for (OutputKey outputKey : outputKeys) {
-            FurnaceOutputPort.outputKey(outputKey.key, outputKey.amount, createAeOutputPort());
         }
         context.markChanged();
     }
 
-    private FurnaceOutputPort.AeOutput createAeOutputPort() {
-        return new FurnaceOutputPort.AeOutput() {
-            @Override
-            public long insertItem(ItemStack stack) {
-                if (!context.isReturnOutputToAe()) return 0;
-                return context.tryOutputToAE(stack);
-            }
+    /**
+     * 尝试把待输出缓冲写入 AE 网络/本地槽位，写不下的部分保留在缓冲中下 tick 重试。
+     *
+     * @return 是否已全部写出
+     */
+    private boolean flushPendingOutputs() {
+        FurnaceOutputPort.AeOutput port = context.createAeOutputPort();
 
-            @Override
-            public long insertFluid(FluidStack stack) {
-                if (!context.isReturnOutputToAe()) return 0;
-                return context.tryOutputFluidToAE(stack);
+        for (int i = 0; i < pendingOutputItems.size(); ) {
+            ItemStack leftover = FurnaceOutputPort.outputItemWithRemainder(pendingOutputItems.get(i), port,
+                    context.getItemHandler(), context.getOutputSlotsStart(), context.getOutputSlotsCount());
+            if (leftover.isEmpty()) {
+                pendingOutputItems.remove(i);
+            } else {
+                pendingOutputItems.set(i, leftover);
+                i++;
             }
+        }
 
-            @Override
-            public long insertKey(AEKey key, long amount) {
-                if (!context.isReturnOutputToAe()) return 0;
-                return context.tryOutputKeyToAE(key, amount);
+        for (int i = 0; i < pendingOutputFluids.size(); ) {
+            FluidStack leftover = FurnaceOutputPort.outputFluidWithRemainder(pendingOutputFluids.get(i), port,
+                    context.getOutputFluidTanks(), context.getFluidTankCount());
+            if (leftover.isEmpty()) {
+                pendingOutputFluids.remove(i);
+            } else {
+                pendingOutputFluids.set(i, leftover);
+                i++;
             }
-        };
+        }
+
+        for (int i = 0; i < pendingOutputKeys.size(); ) {
+            OutputKey pending = pendingOutputKeys.get(i);
+            long inserted = port.insertKey(pending.key, pending.amount);
+            if (inserted >= pending.amount) {
+                pendingOutputKeys.remove(i);
+            } else {
+                pendingOutputKeys.set(i, new OutputKey(pending.key, pending.amount - Math.max(0, inserted)));
+                i++;
+            }
+        }
+
+        boolean flushed = pendingOutputItems.isEmpty() && pendingOutputFluids.isEmpty() && pendingOutputKeys.isEmpty();
+        context.markChanged();
+        return flushed;
     }
 
     public void cancel() {
@@ -614,6 +795,9 @@ public class CraftingTask {
             tag.putInt("MaxParallel", maxParallel);
             tag.putInt("Batches", batches);
             tag.putInt("LastBatchSize", lastBatchSize);
+            tag.putLong("AccumulatedEnergy", accumulatedEnergy);
+            tag.putBoolean("AwaitingOutputFlush", awaitingOutputFlush);
+            tag.put("PendingOutputs", writeStacks(registries, pendingOutputItems, pendingOutputFluids, pendingOutputKeys));
         }
         return tag;
     }
@@ -650,7 +834,7 @@ public class CraftingTask {
         task.updateDisplayedCraftCount();
 
         if (tag.getBoolean("Initialized")) {
-            task.restoreProgress(tag);
+            task.restoreProgress(tag, registries);
         }
         return task;
     }
@@ -659,7 +843,7 @@ public class CraftingTask {
      * 恢复已初始化任务的运行进度，并将进度重新注册进全局进度统计与进度显示对象。
      * 全局 atomic 与 taskProgressRef 不随存档持久化，需要在加载时重建。
      */
-    private void restoreProgress(CompoundTag tag) {
+    private void restoreProgress(CompoundTag tag, HolderLookup.Provider registries) {
         this.baseProcessTime = Math.max(1, tag.getInt("BaseProcessTime"));
         this.baseEnergyPerTick = Math.max(1, tag.getInt("BaseEnergyPerTick"));
         this.maxParallel = Math.max(1, tag.getInt("MaxParallel"));
@@ -667,12 +851,16 @@ public class CraftingTask {
         this.lastBatchSize = Math.max(1, tag.getInt("LastBatchSize"));
         this.processTime = Math.max(1, tag.getInt("ProcessTime"));
         this.progress = Math.max(0, Math.min(tag.getInt("Progress"), this.processTime));
+        this.accumulatedEnergy = Math.max(0L, tag.getLong("AccumulatedEnergy"));
+        this.awaitingOutputFlush = tag.getBoolean("AwaitingOutputFlush");
+        readStacks(registries, tag.getList("PendingOutputs", Tag.TAG_COMPOUND),
+                this.pendingOutputItems, this.pendingOutputFluids, this.pendingOutputKeys);
 
         int outputCount = 1;
         if (pattern != null && !pattern.getOutputs().isEmpty()) {
             outputCount = (int) pattern.getOutputs().getFirst().amount();
         }
-        int totalOutputCount = displayedCraftCount * outputCount;
+        int totalOutputCount = (int) Math.min((long) displayedCraftCount * outputCount, Integer.MAX_VALUE);
         this.taskProgressRef = new AdvancedAlloyFurnaceAeManager.AETaskProgress(getProductName(), processTime, displayedCraftCount, totalOutputCount);
         this.taskProgressRef.setProgress(progress);
         context.getAETaskProgressMap().put(taskId, taskProgressRef);
@@ -713,9 +901,6 @@ public class CraftingTask {
     }
 
     // 辅助类用于存储输出数据
-    private record OutputFluid(FluidStack stack) {
-    }
-
     private record OutputKey(AEKey key, long amount) {
     }
 

--- a/src/main/java/com/sorrowmist/useless/content/machines/advanced_alloy_furnace/ae/CraftingTaskContext.java
+++ b/src/main/java/com/sorrowmist/useless/content/machines/advanced_alloy_furnace/ae/CraftingTaskContext.java
@@ -1,7 +1,9 @@
 package com.sorrowmist.useless.content.machines.advanced_alloy_furnace.ae;
 
 import appeng.api.stacks.AEKey;
+import com.sorrowmist.useless.content.machines.advanced_alloy_furnace.io.FurnaceOutputPort;
 import com.sorrowmist.useless.energy.IEnergyManager;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.capability.templates.FluidTank;
@@ -27,6 +29,7 @@ public interface CraftingTaskContext {
     
     // 基础访问
     Level getLevel();
+    net.minecraft.core.BlockPos getBlockPos();
     ItemStackHandler getItemHandler();
     IEnergyManager getEnergyManager();
     
@@ -44,6 +47,35 @@ public interface CraftingTaskContext {
 
     // 产物输出模式
     boolean isReturnOutputToAe();
+
+    /** 暂存未能返还的输入（AE 写入失败时防丢失，由管理器逐 tick 重试写回） */
+    void stashUnreturnedInput(AEKey key, long amount);
+
+    /**
+     * 统一 AE 输出端口：受“产物返回AE”开关约束，开关关闭时不写入 AE 网络，
+     * 剩余部分由调用方回退到本地槽位。
+     */
+    default FurnaceOutputPort.AeOutput createAeOutputPort() {
+        return new FurnaceOutputPort.AeOutput() {
+            @Override
+            public long insertItem(ItemStack stack) {
+                if (!isReturnOutputToAe()) return 0;
+                return tryOutputToAE(stack);
+            }
+
+            @Override
+            public long insertFluid(FluidStack stack) {
+                if (!isReturnOutputToAe()) return 0;
+                return tryOutputFluidToAE(stack);
+            }
+
+            @Override
+            public long insertKey(AEKey key, long amount) {
+                if (!isReturnOutputToAe()) return 0;
+                return tryOutputKeyToAE(key, amount);
+            }
+        };
+    }
     
     // 任务进度管理
     ConcurrentHashMap<Integer, AdvancedAlloyFurnaceAeManager.AETaskProgress> getAETaskProgressMap();

--- a/src/main/java/com/sorrowmist/useless/content/machines/advanced_alloy_furnace/io/FurnaceOutputPort.java
+++ b/src/main/java/com/sorrowmist/useless/content/machines/advanced_alloy_furnace/io/FurnaceOutputPort.java
@@ -62,34 +62,58 @@ public final class FurnaceOutputPort {
      * 输出单个物品堆，AE 写入失败的剩余部分回退到本地槽位。
      */
     public static void outputItem(ItemStack stack, AeOutput aeOutput, ItemStackHandler itemHandler, int slotsStart, int slotsCount) {
+        outputItemWithRemainder(stack, aeOutput, itemHandler, slotsStart, slotsCount);
+    }
+
+    /**
+     * 输出单个物品堆，AE 写入失败的剩余部分回退到本地槽位。
+     *
+     * @return 本地槽位也放不下的剩余部分（全部放入则为 EMPTY），由调用方决定去向
+     */
+    public static ItemStack outputItemWithRemainder(ItemStack stack, AeOutput aeOutput, ItemStackHandler itemHandler, int slotsStart, int slotsCount) {
         if (stack.isEmpty()) {
-            return;
+            return ItemStack.EMPTY;
         }
         long inserted = aeOutput.insertItem(stack);
         int remainingCount = (int) Math.max(0, stack.getCount() - inserted);
         if (remainingCount <= 0) {
-            return;
+            return ItemStack.EMPTY;
         }
         ItemStack remainingStack = stack.copy();
         remainingStack.setCount(remainingCount);
-        insertItemIntoSlots(remainingStack, itemHandler, slotsStart, slotsCount);
+        int leftover = insertItemIntoSlots(remainingStack, itemHandler, slotsStart, slotsCount);
+        if (leftover <= 0) {
+            return ItemStack.EMPTY;
+        }
+        ItemStack leftoverStack = stack.copy();
+        leftoverStack.setCount(leftover);
+        return leftoverStack;
     }
 
     /**
      * 输出单个流体栈，AE 写入失败的剩余部分回退到本地流体槽。
      */
     public static void outputFluid(FluidStack stack, AeOutput aeOutput, FluidTank[] tanks, int tankCount) {
+        outputFluidWithRemainder(stack, aeOutput, tanks, tankCount);
+    }
+
+    /**
+     * 输出单个流体栈，AE 写入失败的剩余部分回退到本地流体槽。
+     *
+     * @return 流体槽也装不下的剩余部分（全部装入则为 EMPTY），由调用方决定去向
+     */
+    public static FluidStack outputFluidWithRemainder(FluidStack stack, AeOutput aeOutput, FluidTank[] tanks, int tankCount) {
         if (stack.isEmpty()) {
-            return;
+            return FluidStack.EMPTY;
         }
         long inserted = aeOutput.insertFluid(stack);
         int remainingAmount = (int) Math.max(0, stack.getAmount() - inserted);
         if (remainingAmount <= 0) {
-            return;
+            return FluidStack.EMPTY;
         }
         FluidStack remainingFluid = stack.copy();
         remainingFluid.setAmount(remainingAmount);
-        fillFluidTanks(remainingFluid, tanks, tankCount);
+        return fillFluidTanks(remainingFluid, tanks, tankCount);
     }
 
     /**
@@ -99,7 +123,8 @@ public final class FurnaceOutputPort {
         aeOutput.insertKey(key, amount);
     }
 
-    private static void insertItemIntoSlots(ItemStack stack, ItemStackHandler itemHandler, int slotsStart, int slotsCount) {
+    /** @return 槽位放不下的剩余数量 */
+    private static int insertItemIntoSlots(ItemStack stack, ItemStackHandler itemHandler, int slotsStart, int slotsCount) {
         int remainingCount = stack.getCount();
         for (int i = slotsStart; i < slotsStart + slotsCount && remainingCount > 0; i++) {
             ItemStack slotStack = itemHandler.getStackInSlot(i);
@@ -121,9 +146,11 @@ public final class FurnaceOutputPort {
                 remainingCount -= toAdd;
             }
         }
+        return remainingCount;
     }
 
-    private static void fillFluidTanks(FluidStack fluidStack, FluidTank[] tanks, int tankCount) {
+    /** @return 流体槽装不下的剩余部分（全部装入则为 EMPTY） */
+    private static FluidStack fillFluidTanks(FluidStack fluidStack, FluidTank[] tanks, int tankCount) {
         FluidStack remainingFluid = fluidStack.copy();
         for (int i = 0; i < tankCount && !remainingFluid.isEmpty(); i++) {
             FluidTank tank = tanks[i];
@@ -133,5 +160,6 @@ public final class FurnaceOutputPort {
                 remainingFluid.shrink(filled);
             }
         }
+        return remainingFluid;
     }
 }


### PR DESCRIPTION
## 问题背景

### A. 取消 AE 任务不退回材料（材料丢失/复制）

1. GUI 取消任务时，只有活跃任务会返还材料；显示为「排队中/等待模具」的**待启动批次**（AE 推送后尚未转为任务的输入）被 `aePendingBatches.clear()` 直接丢弃。
2. 返还路径被「产物返回AE」开关误伤：开关本意只约束产物去向，却连带挡住取消返还的 AE 写入；本地回退再漏一层——输入槽塞不下的物品、流体槽装不下的流体被静默销毁，AEKey 类材料（如 Mek 化学品）连本地回退都没有，写入失败即消失。
3. `setRemoved()` 先 `mainNode.destroy()` 再触发取消，AE 写回必然失败，拆机时大批材料喷洒掉落；且**区块卸载也走 `setRemoved()`**——任务已随 NBT 保存后又执行返还，重载后任务恢复 + 材料已返还 = 复制漏洞。

### B. 能耗结算与超大批量合成失败

1. 有用锭催化下 AE 任务能耗不符合预期：本体路径通过 `settleCompletionEnergy` 实现「有用锭＝整批只收一份配方能量」，但 CraftingTask（AE 路径）从未接入结算，能耗按 tick × 活跃任务数浮动计费；任务被 `rebalanceTasks` 拆成多个并发后扣能成倍增加。
2. 512M 级请求合成不出来：AE 任务链路多处 int 溢出（输入存储、批次布局、产物生成），溢出后材料变空导致配方匹配失败、或 processTime 溢出为负被钳到 1 tick 造成整批瞬间完成（刷物品漏洞）；批次成熟计时每次推送都被重置，持续推送时任务永不启动；产物写不下时被静默丢弃，AE CPU 永远等不到产物。

## 修复内容

### 取消返还与材料防丢失（CraftingTask / AdvancedAlloyFurnaceAeManager / AdvancedAlloyFurnaceBlock）

- `cancelAllTasks()` 取消时将所有待启动批次的输入合并，经 `CraftingTask.returnInputsToAE` 统一返还，不再随 clear() 丢失；结束后补发进度同步包，修复客户端残留已取消任务的显示
- 拆机/卸载职责拆分：真正拆除时由 `AdvancedAlloyFurnaceBlock.onRemove`（早于 `setRemoved`，AE 节点仍存活）触发取消返还，材料能真正写回 ME 网络；`shutdown()` 不再做取消返还——区块卸载时任务随 NBT 持久化、重载恢复，**消灭卸载复制漏洞**
- 返还与产物一致地尊重「产物返回AE」开关，且任何路径不允许静默丢失：物品 AE → 输入槽 → 掉落机器上方；流体 AE → 输入槽 → 输出槽 → 暂存缓冲；key 类材料无本地槽位可回退，无视开关直接尝试 AE，失败部分进暂存缓冲
- 新增**未返还暂存缓冲**（`unreturnedInputs`，NBT 持久化）：返还失败的化学品/流体每 20 tick 重试写回网络直到成功
- `FurnaceOutputPort` 新增 `outputItemWithRemainder` / `outputFluidWithRemainder`，槽位塞不下的剩余返回调用方处置（原接口行为不变）
- 三份几乎相同的匿名 `AeOutput` 实现收敛为 `CraftingTaskContext.createAeOutputPort()` 单一 default 工厂

### 能耗结算（CraftingTask）

- 新增子任务级完成结算，与本体 `settleCompletionEnergy` 语义对齐：有用锭＝每个子任务恰好一份 `recipe.energy()`（与数量/并行/任务拆分无关）；其他催化剂＝energy × craftCount 整额
- 每 tick 扣能以结算目标为上限，完成时补扣差额；能量不足时分 tick 扣取存量并等待补足
- `startNextSubTask` 重置结算累计，并新增 `refreshCatalystLayout()` 按当前催化剂重算批次布局——中途更换催化剂自下一子任务起生效（旧版布局在初始化时冻结）

### 超大批量（512M 级）支持

- 输入存储与产物生成改为 long 运算＋按 int 上限分块，消除 512M 级数量溢出
- `recalculateBatchLayout` 改 long 运算并饱和，堵住溢出→瞬间完成的刷物品漏洞
- totalCrafts、进度显示 craftCount × outputCount、EAP getMultiplier 统一钳制至 int 上限

### 任务调度与产物安全

- PendingAEBatch 成熟计时改为自建立起算（10 tick 必成熟），持续推送不再无限推迟任务启动
- 产物改为「待输出缓冲＋逐 tick 重试」（`generatePendingOutputs` / `flushPendingOutputs`），AE 网络/输出槽放不下时保留重试、不再静默丢失；全部写出后才进入下一子任务
- 取消任务时，缓冲中已结算未写出的产物随输入材料一并走统一返还路径
- 待输出缓冲与结算能量已加入 NBT 持久化，重载后续跑
- `addMergedBatch` 并入队尾未启动子任务，减少批次数与结算开销

## 行为变化（Breaking）

- 无用锭系催化剂的 AE 任务总能耗补足到 energy × 次数整额（与本体一致）；旧版因缺结算实际少收了时间折扣部分，升级后同任务会比旧版耗能略高
- 「产物返回AE」开关关闭时，取消返还的材料留在机器本地（输入槽，放不下则掉落），不再有任何静默销毁；key 类材料例外——无本地去处，始终尝试写回 AE
- 区块卸载不再触发任务取消，任务随存档恢复续跑

## 已知限制

- 拆除一台不在任何 AE 网络上且含化学品输入的机器时，化学品无法掉落成实体，仍会随方块消失（材料类型的物理限制）
- 即使材料成功退回网络，AE 合成 CPU 侧的任务仍会停在「等待产出」，需玩家在 CPU 上另行取消（AE2 机制限制）

## 验证

- `gradlew compileJava` 通过
- 建议游戏内回归：
  - 取消返还：排队中/等待模具状态下取消可退料；拆机时材料写回 ME 网络；开关关闭时退回输入槽；卸载→重载任务恢复续跑且无复制；化学品样板取消后暂存缓冲重试写回
  - 能耗：有用锭挂大批量 AE 任务观察能量曲线恒为每子任务一份
  - 大批量：512M 赛特斯请求可正常启动、产出并完成

🤖 Generated with [Claude Code](https://claude.com/claude-code)
