### PR TITLE
增加 Data Energistics 样板供应器集成

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -225,7 +225,7 @@ dependencies {
     implementation "curse.maven:ae2-crystal-science-1435174:8498888" // 1.21.1-1.2.1
     implementation "curse.maven:ae2-lightning-tech-1527395:8567287"
     implementation "curse.maven:thunderbolt-core-1631756:8566512"
-    implementation "curse.maven:data-energistics-1565514:8608494" // 1.21.1-3.0.2
+    implementation "curse.maven:data-energistics-1565514:8613673" // 1.21.1-3.0.3
 
     //powah
     implementation "curse.maven:powah-rearchitected-633483:8011715"

--- a/build.gradle
+++ b/build.gradle
@@ -225,7 +225,7 @@ dependencies {
     implementation "curse.maven:ae2-crystal-science-1435174:8498888" // 1.21.1-1.2.1
     implementation "curse.maven:ae2-lightning-tech-1527395:8567287"
     implementation "curse.maven:thunderbolt-core-1631756:8566512"
-    implementation "curse.maven:data-energistics-1565514:8583188" // 1.21.1-2.3.2
+    implementation "curse.maven:data-energistics-1565514:8608494" // 1.21.1-3.0.2
 
     //powah
     implementation "curse.maven:powah-rearchitected-633483:8011715"

--- a/src/main/java/com/sorrowmist/useless/compat/jei/OmniversalPatternJeiTransferHandler.java
+++ b/src/main/java/com/sorrowmist/useless/compat/jei/OmniversalPatternJeiTransferHandler.java
@@ -80,6 +80,30 @@ public final class OmniversalPatternJeiTransferHandler<T extends PatternEncoding
             Player player,
             boolean maxTransfer,
             boolean doTransfer) {
+        return transferOmniversalRecipe(menu, recipe, recipeSlots, player, maxTransfer, doTransfer, this.helper);
+    }
+
+    /**
+     * Transfers a selected alloy-furnace recipe through any AE2 pattern-encoding menu, including optional terminals
+     * that subclass the base menu and register their own exact JEI container type.
+     *
+     * @param menu active AE2-compatible pattern encoding menu
+     * @param recipe exact JEI recipe selection whose identity includes the mold
+     * @param recipeSlots displayed JEI slots for the selected recipe
+     * @param player player requesting the transfer
+     * @param maxTransfer whether JEI requested a maximum transfer
+     * @param doTransfer whether JEI is performing rather than simulating the transfer
+     * @param helper JEI error factory for the active registration
+     * @return a user-facing transfer error, or {@code null} when the transfer succeeds
+     */
+    public static @Nullable IRecipeTransferError transferOmniversalRecipe(
+            PatternEncodingTermMenu menu,
+            AdvancedAlloyFurnaceRecipe recipe,
+            IRecipeSlotsView recipeSlots,
+            Player player,
+            boolean maxTransfer,
+            boolean doTransfer,
+            IRecipeTransferHandlerHelper helper) {
         List<List<GenericStack>> inputs = inputOptions(recipe);
         List<GenericStack> outputs = outputs(recipe);
         if (inputs.isEmpty() || outputs.isEmpty()) {

--- a/src/main/java/com/sorrowmist/useless/content/blockentities/AdvancedAlloyFurnaceBlockEntity.java
+++ b/src/main/java/com/sorrowmist/useless/content/blockentities/AdvancedAlloyFurnaceBlockEntity.java
@@ -1512,7 +1512,7 @@ public class AdvancedAlloyFurnaceBlockEntity extends AEBaseBlockEntity implement
         setChanged();
     }
 
-    public IManagedGridNode getMainNode() {
+    public @NotNull IManagedGridNode getMainNode() {
         return this.mainNode;
     }
 
@@ -1697,7 +1697,7 @@ public class AdvancedAlloyFurnaceBlockEntity extends AEBaseBlockEntity implement
             return;
         }
         IManagedGridNode node = this.getMainNode();
-        if (node != null && node.isActive() && node.getNode() != null
+        if (node.isActive() && node.getNode() != null
                 && node.getNode().getGrid() != null) {
             ICraftingProvider.requestUpdate(node);
         }

--- a/src/main/java/com/sorrowmist/useless/content/blockentities/multiblock/MePatternAssemblyBlockEntity.java
+++ b/src/main/java/com/sorrowmist/useless/content/blockentities/multiblock/MePatternAssemblyBlockEntity.java
@@ -36,6 +36,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import com.sorrowmist.useless.content.menus.MePatternAssemblyMenu;
 import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 
@@ -105,7 +106,7 @@ public final class MePatternAssemblyBlockEntity extends AEBaseBlockEntity
         inventoryChanged();
     }
 
-    public IManagedGridNode getMainNode() {
+    public @NotNull IManagedGridNode getMainNode() {
         return mainNode;
     }
 

--- a/src/main/java/com/sorrowmist/useless/content/recipe/adapters/ae/dataenergistics/DataReassemblerRecipeAdapter.java
+++ b/src/main/java/com/sorrowmist/useless/content/recipe/adapters/ae/dataenergistics/DataReassemblerRecipeAdapter.java
@@ -4,9 +4,9 @@ import appeng.api.stacks.AEFluidKey;
 import appeng.api.stacks.AEItemKey;
 import appeng.api.stacks.AEKey;
 import appeng.api.stacks.GenericStack;
-import com.fish_dan_.data_energistics.recipe.DataRipperReassemblerIngredient;
-import com.fish_dan_.data_energistics.recipe.DataRipperReassemblerRecipe;
-import com.fish_dan_.data_energistics.registry.ModRecipes;
+import com.fish_dan_.data_energistics.recipe.reassembler.DataRipperReassemblerIngredient;
+import com.fish_dan_.data_energistics.recipe.reassembler.DataRipperReassemblerRecipe;
+import com.fish_dan_.data_energistics.registry.DERecipes;
 import com.sorrowmist.useless.api.enums.AlloyFurnaceMode;
 import com.sorrowmist.useless.content.recipe.AdapterUtils;
 import com.sorrowmist.useless.content.recipe.AdvancedAlloyFurnaceRecipe;
@@ -180,10 +180,10 @@ public class DataReassemblerRecipeAdapter implements IRecipeAdapter<DataRipperRe
 
         RecipeManager recipeManager = level.getRecipeManager();
         List<RecipeHolder<DataRipperReassemblerRecipe>> recipes = (List<RecipeHolder<DataRipperReassemblerRecipe>>) (List<?>) recipeManager.getAllRecipesFor(
-                ModRecipes.DATA_RIPPER_REASSEMBLER_TYPE.get()
+                DERecipes.DATA_RIPPER_REASSEMBLER_TYPE.get()
         );
 
-        List<RecipeHolder<DataRipperReassemblerRecipe>> matches = new java.util.ArrayList<>();
+        List<RecipeHolder<DataRipperReassemblerRecipe>> matches = new ArrayList<>();
 
         for (RecipeHolder<DataRipperReassemblerRecipe> holder : recipes) {
             DataRipperReassemblerRecipe recipe = holder.value();

--- a/src/main/java/com/sorrowmist/useless/integration/dataenergistics/jei/UselessDataEnergisticsJeiPlugin.java
+++ b/src/main/java/com/sorrowmist/useless/integration/dataenergistics/jei/UselessDataEnergisticsJeiPlugin.java
@@ -1,0 +1,61 @@
+package com.sorrowmist.useless.integration.dataenergistics.jei;
+
+import com.fish_dan_.data_energistics.api.entrypoint.jei.DataEnergisticsJeiEntrypoint;
+import com.fish_dan_.data_energistics.api.entrypoint.jei.DataEnergisticsJeiPlugin;
+import com.fish_dan_.data_energistics.api.entrypoint.jei.DataEnergisticsJeiRegistry;
+import com.fish_dan_.data_energistics.menu.universal.UniversalPatternEncodingTermMenu;
+import com.fish_dan_.data_energistics.registry.DEMenus;
+import com.sorrowmist.useless.UselessMod;
+import com.sorrowmist.useless.compat.jei.AdvancedAlloyFurnaceRecipeCategory;
+import com.sorrowmist.useless.compat.jei.OmniversalPatternJeiTransferHandler;
+
+import appeng.menu.me.items.PatternEncodingTermMenu;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.inventory.MenuType;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Makes Data Energistics's universal pattern encoding terminal preserve the exact Omniversal Pattern recipe,
+ * including its internal mold, when a player transfers a recipe from JEI.
+ */
+@DataEnergisticsJeiEntrypoint
+public final class UselessDataEnergisticsJeiPlugin implements DataEnergisticsJeiPlugin {
+    private static final ResourceLocation OMNIVERSAL_PATTERN_TRANSFER_ID =
+            UselessMod.id("omniversal_pattern_transfer");
+
+    /** Public constructor required by Data Energistics's JEI entrypoint scanner. */
+    public UselessDataEnergisticsJeiPlugin() {}
+
+    @Override
+    public void register(@NotNull DataEnergisticsJeiRegistry registry) {
+        registerTransfer(
+                registry,
+                UniversalPatternEncodingTermMenu.class,
+                DEMenus.UNIVERSAL_PATTERN_ENCODING_TERM.get());
+    }
+
+    /**
+     * Registers the alloy-furnace category transfer for one concrete AE2-compatible pattern-encoding menu.
+     *
+     * @param registry Data Energistics's generic JEI registration surface
+     * @param menuClass exact terminal menu class
+     * @param menuType exact terminal menu registration
+     * @param <T> concrete pattern-encoding menu type
+     */
+    static <T extends PatternEncodingTermMenu> void registerTransfer(
+            @NotNull DataEnergisticsJeiRegistry registry,
+            @NotNull Class<T> menuClass,
+            @NotNull MenuType<T> menuType) {
+        registry.registerRecipeTransferHandler(
+                OMNIVERSAL_PATTERN_TRANSFER_ID,
+                menuClass,
+                menuType,
+                AdvancedAlloyFurnaceRecipeCategory.TYPE,
+                helper -> new OmniversalPatternJeiTransferHandler<>(
+                        menuClass,
+                        menuType,
+                        helper));
+    }
+}

--- a/src/main/java/com/sorrowmist/useless/integration/dataenergistics/provider/AlloyFurnaceCountedCraftingAdapter.java
+++ b/src/main/java/com/sorrowmist/useless/integration/dataenergistics/provider/AlloyFurnaceCountedCraftingAdapter.java
@@ -1,0 +1,260 @@
+package com.sorrowmist.useless.integration.dataenergistics.provider;
+
+import appeng.api.crafting.IPatternDetails;
+import appeng.api.networking.crafting.ICraftingProvider;
+import appeng.api.stacks.KeyCounter;
+import com.fish_dan_.data_energistics.api.crafting.dispatch.CountedCraftingAdmission;
+import com.fish_dan_.data_energistics.api.crafting.dispatch.CountedCraftingCapacity;
+import com.fish_dan_.data_energistics.api.crafting.dispatch.CountedCraftingProviderAdapter;
+import com.fish_dan_.data_energistics.api.crafting.dispatch.CountedCraftingRoutingMode;
+import com.fish_dan_.data_energistics.api.crafting.dispatch.CountedCraftingTarget;
+import com.fish_dan_.data_energistics.api.registry.provider.runtime.PatternProviderIdentity;
+import com.sorrowmist.useless.content.blockentities.AdvancedAlloyFurnaceBlockEntity;
+import com.sorrowmist.useless.content.blockentities.multiblock.MePatternAssemblyBlockEntity;
+import com.sorrowmist.useless.content.machines.advanced_alloy_furnace.ae.ScaledProcessingPattern;
+import com.sorrowmist.useless.content.machines.advanced_alloy_furnace.ae.SmartDoublingPatterns;
+import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.OptionalLong;
+import java.util.function.BooleanSupplier;
+
+/**
+ * Bridges one alloy-furnace AE provider to Data Energistics counted Trinity dispatch.
+ *
+ * <p>The adapter converts one accepted logical batch into a single scaled pattern push. This preserves the
+ * furnace's native queueing and task-splitting behavior while avoiding per-craft provider calls.</p>
+ */
+final class AlloyFurnaceCountedCraftingAdapter implements CountedCraftingProviderAdapter {
+    private final ICraftingProvider provider;
+    private final BooleanSupplier online;
+    private final CountedCraftingTarget target;
+
+    AlloyFurnaceCountedCraftingAdapter(
+            @NotNull ICraftingProvider provider,
+            @NotNull BooleanSupplier online,
+            @NotNull CountedCraftingTarget target) {
+        this.provider = provider;
+        this.online = online;
+        this.target = target;
+    }
+
+    /** Creates the live adapter used by one standalone advanced alloy furnace. */
+    static AlloyFurnaceCountedCraftingAdapter forAdvancedAlloyFurnace(
+            @NotNull AdvancedAlloyFurnaceBlockEntity provider,
+            @NotNull PatternProviderIdentity identity) {
+        return new AlloyFurnaceCountedCraftingAdapter(
+                provider,
+                () -> isAdvancedAlloyFurnaceOnline(provider),
+                targetFor(identity));
+    }
+
+    /** Creates the live adapter used by one ME pattern assembly and its linked multiblock controller. */
+    static AlloyFurnaceCountedCraftingAdapter forMePatternAssembly(
+            @NotNull MePatternAssemblyBlockEntity provider,
+            @NotNull PatternProviderIdentity identity) {
+        return new AlloyFurnaceCountedCraftingAdapter(
+                provider,
+                () -> isMePatternAssemblyOnline(provider),
+                targetFor(identity));
+    }
+
+    @Override
+    public @Nullable CountedCraftingAdmission prepareBatch(
+            @NotNull IPatternDetails patternDetails, KeyCounter @NotNull [] prototype, long requestedCount) {
+        return prepareAdmission(patternDetails, prototype, requestedCount);
+    }
+
+    @Override
+    public @NotNull List<@NotNull CountedCraftingCapacity> captureCapacity(
+            @NotNull IPatternDetails patternDetails, KeyCounter @NotNull [] prototype, long requestedCount) {
+        long acceptedCount = availableCount(patternDetails, prototype, requestedCount);
+        if (acceptedCount == 0L) {
+            return List.of();
+        }
+        return List.of(new CountedCraftingCapacity(
+                target,
+                CountedCraftingRoutingMode.TARGETED,
+                OptionalLong.of(acceptedCount),
+                OptionalLong.of(acceptedCount)));
+    }
+
+    @Override
+    public @Nullable CountedCraftingAdmission prepareBatchForTarget(
+            @NotNull IPatternDetails patternDetails,
+            KeyCounter @NotNull [] prototype,
+            long requestedCount,
+            @NotNull CountedCraftingTarget requestedTarget) {
+        return target.equals(requestedTarget)
+                ? prepareAdmission(patternDetails, prototype, requestedCount)
+                : null;
+    }
+
+    /** Returns the largest safe count for one physical scaled-pattern submission. */
+    static long maximumBatchCount(
+            @NotNull IPatternDetails patternDetails,
+            KeyCounter @NotNull [] prototype,
+            long requestedCount) {
+        validateRequestedCount(requestedCount);
+        SmartDoublingPatterns.Resolved execution = SmartDoublingPatterns.resolve(patternDetails);
+        long maximumCount = SmartDoublingPatterns.maximumSafeMultiplier(execution.pattern())
+                / execution.operationsPerPush();
+        for (KeyCounter counter : prototype) {
+            for (var entry : counter) {
+                long amount = entry.getLongValue();
+                if (amount < 0L) {
+                    throw new IllegalArgumentException("Crafting input amounts must not be negative");
+                }
+                if (amount > 0L) {
+                    maximumCount = Math.min(maximumCount, Long.MAX_VALUE / amount);
+                }
+            }
+        }
+        return Math.min(requestedCount, maximumCount);
+    }
+
+    /** Creates a deep, exact scaled input snapshot without changing the caller-owned prototype. */
+    static KeyCounter[] scalePrototype(KeyCounter @NotNull [] prototype, long count) {
+        if (count <= 0L) {
+            throw new IllegalArgumentException("Counted crafting batch size must be positive");
+        }
+        KeyCounter[] scaled = new KeyCounter[prototype.length];
+        for (int index = 0; index < prototype.length; index++) {
+            KeyCounter source = prototype[index];
+            KeyCounter targetCounter = new KeyCounter();
+            for (var entry : source) {
+                long amount = entry.getLongValue();
+                if (amount < 0L) {
+                    throw new IllegalArgumentException("Crafting input amounts must not be negative");
+                }
+                targetCounter.add(entry.getKey(), Math.multiplyExact(amount, count));
+            }
+            scaled[index] = targetCounter;
+        }
+        return scaled;
+    }
+
+    private @Nullable CountedCraftingAdmission prepareAdmission(
+            @NotNull IPatternDetails patternDetails,
+            KeyCounter @NotNull [] prototype,
+            long requestedCount) {
+        long acceptedCount = availableCount(patternDetails, prototype, requestedCount);
+        return acceptedCount == 0L
+                ? null
+                : new AlloyFurnaceCountedCraftingAdmission(this, patternDetails, prototype, acceptedCount);
+    }
+
+    private long availableCount(
+            @NotNull IPatternDetails patternDetails,
+            KeyCounter @NotNull [] prototype,
+            long requestedCount) {
+        validateRequestedCount(requestedCount);
+        if (!online.getAsBoolean()) {
+            return 0L;
+        }
+        IPatternDetails original = SmartDoublingPatterns.unwrap(patternDetails);
+        if (!provider.getAvailablePatterns().contains(original)) {
+            return 0L;
+        }
+        return maximumBatchCount(patternDetails, prototype, requestedCount);
+    }
+
+    private boolean dispatch(
+            @NotNull IPatternDetails patternDetails,
+            KeyCounter @NotNull [] prototype,
+            long count) {
+        if (availableCount(patternDetails, prototype, count) < count) {
+            return false;
+        }
+        ScaledProcessingPattern scaledPattern = new ScaledProcessingPattern(patternDetails, count);
+        KeyCounter[] scaledPrototype = scalePrototype(prototype, count);
+        return provider.pushPattern(scaledPattern, scaledPrototype);
+    }
+
+    static CountedCraftingTarget targetFor(@NotNull PatternProviderIdentity identity) {
+        String digest = identity.digest();
+        return CountedCraftingTarget.machine(digest, digest);
+    }
+
+    private static boolean isAdvancedAlloyFurnaceOnline(@NotNull AdvancedAlloyFurnaceBlockEntity provider) {
+        Level level = provider.getLevel();
+        return level != null
+                && !level.isClientSide
+                && !provider.isRemoved()
+                && provider.getMainNode().isActive();
+    }
+
+    private static boolean isMePatternAssemblyOnline(@NotNull MePatternAssemblyBlockEntity provider) {
+        Level level = provider.getLevel();
+        return level != null
+                && !level.isClientSide
+                && !provider.isRemoved()
+                && provider.getMainNode().isActive()
+                && provider.getController() != null;
+    }
+
+    private static void validateRequestedCount(long requestedCount) {
+        if (requestedCount <= 0L) {
+            throw new IllegalArgumentException("Requested counted crafting amount must be positive");
+        }
+    }
+
+    /** One-shot admission that owns only temporary dispatch references until it is committed. */
+    private static final class AlloyFurnaceCountedCraftingAdmission implements CountedCraftingAdmission {
+        private AdmissionState state;
+        private final long count;
+        private boolean transferredInputOwnership;
+
+        private AlloyFurnaceCountedCraftingAdmission(
+                @NotNull AlloyFurnaceCountedCraftingAdapter adapter,
+                @NotNull IPatternDetails patternDetails,
+                KeyCounter @NotNull [] preparedPrototype,
+                long count) {
+            this.state = new PreparedAdmissionState(adapter, patternDetails, preparedPrototype);
+            this.count = count;
+        }
+
+        @Override
+        public long count() {
+            return count;
+        }
+
+        @Override
+        public boolean hasTransferredInputOwnership() {
+            return transferredInputOwnership;
+        }
+
+        @Override
+        public boolean commit(KeyCounter @NotNull [] prototype) {
+            if (!(state instanceof PreparedAdmissionState(
+                    AlloyFurnaceCountedCraftingAdapter adapter,
+                    IPatternDetails patternDetails,
+                    KeyCounter[] preparedPrototype))) {
+                throw new IllegalStateException("Admission has already been committed");
+            }
+            if (prototype != preparedPrototype) {
+                throw new IllegalArgumentException("Admission must be committed with its prepared prototype");
+            }
+            state = ReleasedAdmissionState.RELEASED;
+            boolean accepted = adapter.dispatch(patternDetails, prototype, count);
+            transferredInputOwnership = accepted;
+            return accepted;
+        }
+
+        /** The admission's retained state is either dispatchable once or already released. */
+        private sealed interface AdmissionState permits PreparedAdmissionState, ReleasedAdmissionState {}
+
+        /** Retains the server-thread data required to execute exactly one provider dispatch. */
+        private record PreparedAdmissionState(
+                @NotNull AlloyFurnaceCountedCraftingAdapter adapter,
+                @NotNull IPatternDetails patternDetails,
+                KeyCounter @NotNull [] prototype) implements AdmissionState {}
+
+        /** Drops all temporary references as soon as the only commit attempt begins. */
+        private enum ReleasedAdmissionState implements AdmissionState {
+            RELEASED
+        }
+    }
+}

--- a/src/main/java/com/sorrowmist/useless/integration/dataenergistics/provider/UselessDataEnergisticsPatternProviderPlugin.java
+++ b/src/main/java/com/sorrowmist/useless/integration/dataenergistics/provider/UselessDataEnergisticsPatternProviderPlugin.java
@@ -1,0 +1,122 @@
+package com.sorrowmist.useless.integration.dataenergistics.provider;
+
+import com.fish_dan_.data_energistics.api.crafting.dispatch.CountedCraftingProviderAdapter;
+import com.fish_dan_.data_energistics.api.entrypoint.DataEnergisticsEntrypoint;
+import com.fish_dan_.data_energistics.api.entrypoint.DataEnergisticsPlugin;
+import com.fish_dan_.data_energistics.api.entrypoint.DataEnergisticsRegistry;
+import com.fish_dan_.data_energistics.api.registry.provider.PatternProviderRegistry;
+import com.fish_dan_.data_energistics.api.registry.provider.callback.PatternProviderPostCommitContext;
+import com.fish_dan_.data_energistics.api.registry.provider.definition.PatternProviderMetadata;
+import com.fish_dan_.data_energistics.api.registry.provider.definition.PatternProviderRegistration;
+import com.fish_dan_.data_energistics.api.registry.provider.definition.ProviderIdentityDescriptor;
+import com.fish_dan_.data_energistics.api.registry.provider.runtime.PatternProviderFactoryContext;
+import com.sorrowmist.useless.UselessMod;
+import com.sorrowmist.useless.content.blockentities.AdvancedAlloyFurnaceBlockEntity;
+import com.sorrowmist.useless.content.blockentities.multiblock.MePatternAssemblyBlockEntity;
+import com.sorrowmist.useless.init.ModBlockEntities;
+import com.sorrowmist.useless.init.ModBlocks;
+import net.minecraft.resources.ResourceLocation;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+/** Registers UselessMod alloy-furnace providers with Data Energistics during its common setup scan. */
+@DataEnergisticsEntrypoint
+public final class UselessDataEnergisticsPatternProviderPlugin implements DataEnergisticsPlugin {
+    private static final ResourceLocation RECIPE_CATEGORY_ID = UselessMod.id("advanced_alloy_furnace");
+    private static final ResourceLocation ADVANCED_ALLOY_FURNACE_REGISTRATION_ID =
+            UselessMod.id("advanced_alloy_furnace");
+    private static final ResourceLocation ME_PATTERN_ASSEMBLY_REGISTRATION_ID =
+            UselessMod.id("me_pattern_assembly");
+
+    /** Public constructor required by the Data Energistics entrypoint scanner. */
+    public UselessDataEnergisticsPatternProviderPlugin() {}
+
+    @Override
+    public void register(@NotNull DataEnergisticsRegistry registry) {
+        ResourceLocation advancedAlloyFurnaceTypeId = ModBlockEntities.ADVANCED_ALLOY_FURNACE.getId();
+        ResourceLocation advancedAlloyFurnaceItemId = ModBlocks.ADVANCED_ALLOY_FURNACE_BLOCK.getId();
+        ResourceLocation mePatternAssemblyTypeId = ModBlockEntities.ME_PATTERN_ASSEMBLY.getId();
+        ResourceLocation mePatternAssemblyItemId = ModBlocks.ME_PATTERN_ASSEMBLY.getId();
+        registerAll(registry.patternProviders(), createRegistrations(
+                advancedAlloyFurnaceTypeId,
+                advancedAlloyFurnaceItemId,
+                mePatternAssemblyTypeId,
+                mePatternAssemblyItemId));
+    }
+
+    /** Creates the two immutable provider declarations used by this integration. */
+    static @NotNull List<@NotNull PatternProviderRegistration> createRegistrations(
+            @NotNull ResourceLocation advancedAlloyFurnaceTypeId,
+            @NotNull ResourceLocation advancedAlloyFurnaceItemId,
+            @NotNull ResourceLocation mePatternAssemblyTypeId,
+            @NotNull ResourceLocation mePatternAssemblyItemId) {
+        return List.of(
+                new PatternProviderRegistration(
+                        metadata(
+                                ADVANCED_ALLOY_FURNACE_REGISTRATION_ID,
+                                advancedAlloyFurnaceTypeId,
+                                advancedAlloyFurnaceItemId),
+                        UselessDataEnergisticsPatternProviderPlugin::createAdvancedAlloyFurnaceAdapter,
+                        null,
+                        UselessDataEnergisticsPatternProviderPlugin::markAdvancedAlloyFurnaceChanged),
+                new PatternProviderRegistration(
+                        metadata(
+                                ME_PATTERN_ASSEMBLY_REGISTRATION_ID,
+                                mePatternAssemblyTypeId,
+                                mePatternAssemblyItemId),
+                        UselessDataEnergisticsPatternProviderPlugin::createMePatternAssemblyAdapter,
+                        null,
+                        UselessDataEnergisticsPatternProviderPlugin::markMePatternAssemblyChanged));
+    }
+
+    /** Registers every declaration as a separate atomic Data Energistics provider registration. */
+    static void registerAll(
+            @NotNull PatternProviderRegistry registry,
+            @NotNull List<@NotNull PatternProviderRegistration> registrations) {
+        for (PatternProviderRegistration registration : registrations) {
+            registry.register(registration);
+        }
+    }
+
+    private static @NotNull PatternProviderMetadata metadata(
+            @NotNull ResourceLocation registrationId,
+            @NotNull ResourceLocation blockEntityTypeId,
+            @NotNull ResourceLocation workstationItemId) {
+        return new PatternProviderMetadata(
+                registrationId,
+                new ProviderIdentityDescriptor.Block(blockEntityTypeId),
+                List.of(RECIPE_CATEGORY_ID),
+                List.of(workstationItemId));
+    }
+
+    private static @NotNull CountedCraftingProviderAdapter createAdvancedAlloyFurnaceAdapter(
+            @NotNull PatternProviderFactoryContext context) {
+        if (!(context.provider() instanceof AdvancedAlloyFurnaceBlockEntity provider)) {
+            throw new IllegalArgumentException("Advanced alloy furnace registration received an unexpected provider");
+        }
+        return AlloyFurnaceCountedCraftingAdapter.forAdvancedAlloyFurnace(provider, context.identity());
+    }
+
+    private static @NotNull CountedCraftingProviderAdapter createMePatternAssemblyAdapter(
+            @NotNull PatternProviderFactoryContext context) {
+        if (!(context.provider() instanceof MePatternAssemblyBlockEntity provider)) {
+            throw new IllegalArgumentException("ME pattern assembly registration received an unexpected provider");
+        }
+        return AlloyFurnaceCountedCraftingAdapter.forMePatternAssembly(provider, context.identity());
+    }
+
+    private static void markAdvancedAlloyFurnaceChanged(@NotNull PatternProviderPostCommitContext context) {
+        if (!(context.provider() instanceof AdvancedAlloyFurnaceBlockEntity provider)) {
+            throw new IllegalArgumentException("Advanced alloy furnace commit received an unexpected provider");
+        }
+        provider.setChanged();
+    }
+
+    private static void markMePatternAssemblyChanged(@NotNull PatternProviderPostCommitContext context) {
+        if (!(context.provider() instanceof MePatternAssemblyBlockEntity provider)) {
+            throw new IllegalArgumentException("ME pattern assembly commit received an unexpected provider");
+        }
+        provider.setChanged();
+    }
+}

--- a/src/main/java/com/sorrowmist/useless/integration/dataenergistics/provider/UselessDataEnergisticsPatternProviderPlugin.java
+++ b/src/main/java/com/sorrowmist/useless/integration/dataenergistics/provider/UselessDataEnergisticsPatternProviderPlugin.java
@@ -10,11 +10,14 @@ import com.fish_dan_.data_energistics.api.registry.provider.definition.PatternPr
 import com.fish_dan_.data_energistics.api.registry.provider.definition.PatternProviderRegistration;
 import com.fish_dan_.data_energistics.api.registry.provider.definition.ProviderIdentityDescriptor;
 import com.fish_dan_.data_energistics.api.registry.provider.runtime.PatternProviderFactoryContext;
+import com.fish_dan_.data_energistics.api.registry.search.TrinityPatternSearchRegistry;
+import com.fish_dan_.data_energistics.api.registry.search.TrinityPatternSearchTermRegistration;
 import com.sorrowmist.useless.UselessMod;
 import com.sorrowmist.useless.content.blockentities.AdvancedAlloyFurnaceBlockEntity;
 import com.sorrowmist.useless.content.blockentities.multiblock.MePatternAssemblyBlockEntity;
 import com.sorrowmist.useless.init.ModBlockEntities;
 import com.sorrowmist.useless.init.ModBlocks;
+import com.sorrowmist.useless.integration.dataenergistics.search.OmniversalPatternMoldSearchTerms;
 import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.NotNull;
 
@@ -28,6 +31,8 @@ public final class UselessDataEnergisticsPatternProviderPlugin implements DataEn
             UselessMod.id("advanced_alloy_furnace");
     private static final ResourceLocation ME_PATTERN_ASSEMBLY_REGISTRATION_ID =
             UselessMod.id("me_pattern_assembly");
+    private static final ResourceLocation OMNIVERSAL_PATTERN_MOLD_SEARCH_REGISTRATION_ID =
+            UselessMod.id("omniversal_pattern_mold_search");
 
     /** Public constructor required by the Data Energistics entrypoint scanner. */
     public UselessDataEnergisticsPatternProviderPlugin() {}
@@ -43,6 +48,7 @@ public final class UselessDataEnergisticsPatternProviderPlugin implements DataEn
                 advancedAlloyFurnaceItemId,
                 mePatternAssemblyTypeId,
                 mePatternAssemblyItemId));
+        registerSearchTerms(registry.trinityPatternSearch());
     }
 
     /** Creates the two immutable provider declarations used by this integration. */
@@ -77,6 +83,13 @@ public final class UselessDataEnergisticsPatternProviderPlugin implements DataEn
         for (PatternProviderRegistration registration : registrations) {
             registry.register(registration);
         }
+    }
+
+    /** Registers the hidden mold stored in an Omniversal Pattern as an independent Trinity search candidate. */
+    static void registerSearchTerms(@NotNull TrinityPatternSearchRegistry registry) {
+        registry.register(new TrinityPatternSearchTermRegistration(
+                OMNIVERSAL_PATTERN_MOLD_SEARCH_REGISTRATION_ID,
+                OmniversalPatternMoldSearchTerms::searchTerms));
     }
 
     private static @NotNull PatternProviderMetadata metadata(

--- a/src/main/java/com/sorrowmist/useless/integration/dataenergistics/search/OmniversalPatternMoldSearchTerms.java
+++ b/src/main/java/com/sorrowmist/useless/integration/dataenergistics/search/OmniversalPatternMoldSearchTerms.java
@@ -1,0 +1,43 @@
+package com.sorrowmist.useless.integration.dataenergistics.search;
+
+import com.sorrowmist.useless.core.component.OmniversalPatternData;
+import com.sorrowmist.useless.core.component.UComponents;
+
+import net.minecraft.world.item.ItemStack;
+
+import java.util.List;
+
+/**
+ * Extracts the encoded internal mold as a separate Trinity pattern-search candidate.
+ */
+public final class OmniversalPatternMoldSearchTerms {
+
+    private OmniversalPatternMoldSearchTerms() {}
+
+    /**
+     * Returns the mold display name stored in one Omniversal Pattern, when that pattern needs a mold.
+     *
+     * @param encodedPattern candidate encoded pattern stack
+     * @return one independent mold-name candidate, or no candidates for every other pattern
+     */
+    public static List<String> searchTerms(ItemStack encodedPattern) {
+        OmniversalPatternData data = encodedPattern.get(UComponents.OMNIVERSAL_PATTERN_DATA.get());
+        return data == null ? List.of() : searchTerms(data);
+    }
+
+    /**
+     * Returns one display candidate for metadata that has already been decoded from an Omniversal Pattern.
+     *
+     * @param data persisted Omniversal Pattern metadata
+     * @return one independent mold-name candidate, or no candidate when no mold is required
+     */
+    static List<String> searchTerms(OmniversalPatternData data) {
+        if (!data.requiresMold()) {
+            return List.of();
+        }
+        return data.displayMold()
+                .map(key -> key.getDisplayName().getString())
+                .stream()
+                .toList();
+    }
+}

--- a/src/test/java/com/sorrowmist/useless/integration/dataenergistics/DataEnergisticsIntegrationTestBootstrap.java
+++ b/src/test/java/com/sorrowmist/useless/integration/dataenergistics/DataEnergisticsIntegrationTestBootstrap.java
@@ -1,0 +1,54 @@
+package com.sorrowmist.useless.integration.dataenergistics;
+
+import appeng.api.stacks.AEKeyType;
+import appeng.api.stacks.AEKeyTypesInternal;
+
+import net.minecraft.SharedConstants;
+import net.minecraft.core.Registry;
+import net.minecraft.server.Bootstrap;
+import net.neoforged.fml.loading.LoadingModList;
+import net.neoforged.neoforge.registries.RegistryBuilder;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Initializes the Minecraft and AE key registries required by direct Data Energistics integration tests.
+ */
+@SuppressWarnings("UnstableApiUsage")
+public final class DataEnergisticsIntegrationTestBootstrap {
+
+    private DataEnergisticsIntegrationTestBootstrap() {}
+
+    /**
+     * Initializes each registry only once for the active JUnit worker.
+     */
+    public static void initialize() {
+        if (LoadingModList.get() == null) {
+            LoadingModList.of(List.of(), List.of(), List.of(), List.of(), Map.of());
+        }
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+        initializeAeKeyTypes();
+    }
+
+    private static void initializeAeKeyTypes() {
+        synchronized (AEKeyTypesInternal.class) {
+            boolean initialized;
+            try {
+                initialized = AEKeyTypesInternal.getRegistry() != null;
+            } catch (IllegalStateException notInitialized) {
+                initialized = false;
+            }
+            if (!initialized) {
+                Registry<AEKeyType> registry = new RegistryBuilder<>(AEKeyType.REGISTRY_KEY)
+                        .disableRegistrationCheck()
+                        .create();
+                AEKeyTypesInternal.setRegistry(registry);
+                Registry.register(registry, AEKeyType.items().getId(), AEKeyType.items());
+                Registry.register(registry, AEKeyType.fluids().getId(), AEKeyType.fluids());
+                registry.freeze();
+            }
+        }
+    }
+}

--- a/src/test/java/com/sorrowmist/useless/integration/dataenergistics/jei/UselessDataEnergisticsJeiPluginTest.java
+++ b/src/test/java/com/sorrowmist/useless/integration/dataenergistics/jei/UselessDataEnergisticsJeiPluginTest.java
@@ -1,0 +1,74 @@
+package com.sorrowmist.useless.integration.dataenergistics.jei;
+
+import appeng.menu.me.items.PatternEncodingTermMenu;
+
+import com.fish_dan_.data_energistics.api.entrypoint.jei.DataEnergisticsJeiRegistry;
+import com.fish_dan_.data_energistics.api.entrypoint.jei.JeiRecipeTransferHandlerFactory;
+import com.sorrowmist.useless.UselessMod;
+import com.sorrowmist.useless.compat.jei.AdvancedAlloyFurnaceRecipeCategory;
+import com.sorrowmist.useless.integration.dataenergistics.DataEnergisticsIntegrationTestBootstrap;
+
+import mezz.jei.api.recipe.RecipeType;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.flag.FeatureFlags;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.MenuType;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class UselessDataEnergisticsJeiPluginTest {
+
+    @BeforeAll
+    static void bootstrapMinecraft() {
+        DataEnergisticsIntegrationTestBootstrap.initialize();
+    }
+
+    @Test
+    void registersTheExactMoldAwareTransferThroughTheGenericJeiSurface() {
+        RecordingRegistry registry = new RecordingRegistry();
+        MenuType<PatternEncodingTermMenu> menuType = new MenuType<>(
+                (containerId, inventory) -> {
+                    throw new AssertionError("The registration test must not create a menu");
+                },
+                FeatureFlags.VANILLA_SET);
+
+        UselessDataEnergisticsJeiPlugin.registerTransfer(
+                registry,
+                PatternEncodingTermMenu.class,
+                menuType);
+
+        assertEquals(UselessMod.id("omniversal_pattern_transfer"), registry.registrationId);
+        assertEquals(PatternEncodingTermMenu.class, registry.menuClass);
+        assertEquals(menuType, registry.menuType);
+        assertEquals(AdvancedAlloyFurnaceRecipeCategory.TYPE, registry.recipeType);
+        assertNotNull(registry.factory);
+    }
+
+    private static final class RecordingRegistry implements DataEnergisticsJeiRegistry {
+        private ResourceLocation registrationId;
+        private Class<?> menuClass;
+        private MenuType<?> menuType;
+        private RecipeType<?> recipeType;
+        private JeiRecipeTransferHandlerFactory<?, ?> factory;
+
+        @Override
+        public <T extends AbstractContainerMenu, R> void registerRecipeTransferHandler(
+                @NotNull ResourceLocation registrationId,
+                @NotNull Class<T> menuClass,
+                @NotNull MenuType<T> menuType,
+                @NotNull RecipeType<R> recipeType,
+                @NotNull JeiRecipeTransferHandlerFactory<T, R> factory) {
+            this.registrationId = registrationId;
+            this.menuClass = menuClass;
+            this.menuType = menuType;
+            this.recipeType = recipeType;
+            this.factory = factory;
+        }
+    }
+}

--- a/src/test/java/com/sorrowmist/useless/integration/dataenergistics/provider/AlloyFurnaceCountedCraftingAdapterTest.java
+++ b/src/test/java/com/sorrowmist/useless/integration/dataenergistics/provider/AlloyFurnaceCountedCraftingAdapterTest.java
@@ -1,0 +1,285 @@
+package com.sorrowmist.useless.integration.dataenergistics.provider;
+
+import appeng.api.crafting.IPatternDetails;
+import appeng.api.networking.crafting.ICraftingProvider;
+import appeng.api.stacks.AEItemKey;
+import appeng.api.stacks.AEKey;
+import appeng.api.stacks.GenericStack;
+import appeng.api.stacks.KeyCounter;
+import com.fish_dan_.data_energistics.api.crafting.dispatch.CountedCraftingAdmission;
+import com.fish_dan_.data_energistics.api.crafting.dispatch.CountedCraftingCapacity;
+import com.fish_dan_.data_energistics.api.crafting.dispatch.CountedCraftingTarget;
+import com.fish_dan_.data_energistics.api.registry.provider.definition.ProviderIdentityDescriptor;
+import com.fish_dan_.data_energistics.api.registry.provider.runtime.PatternProviderIdentity;
+import com.sorrowmist.useless.content.machines.advanced_alloy_furnace.ae.ScaledProcessingPattern;
+import net.minecraft.SharedConstants;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AlloyFurnaceCountedCraftingAdapterTest {
+    private static final CountedCraftingTarget TARGET =
+            CountedCraftingTarget.machine("test-route", "test-machine");
+
+    @BeforeAll
+    static void bootstrapMinecraft() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    @Test
+    void publishesTargetedSafeCapacityForAnOnlineProvider() {
+        TestPattern pattern = pattern(2L, 2L, 3L);
+        AEItemKey input = itemKey(Items.IRON_INGOT);
+        AlloyFurnaceCountedCraftingAdapter adapter = new AlloyFurnaceCountedCraftingAdapter(
+                new TestProvider(pattern), () -> true, TARGET);
+
+        List<CountedCraftingCapacity> capacities = adapter.captureCapacity(
+                pattern, prototype(input, 2L), 7L);
+
+        assertEquals(1, capacities.size());
+        CountedCraftingCapacity capacity = capacities.getFirst();
+        assertEquals(TARGET, capacity.target());
+        assertEquals(7L, capacity.logicalCrafts().orElseThrow());
+        assertEquals(7L, capacity.maximumSingleBatch().orElseThrow());
+    }
+
+    @Test
+    void publishesTargetedSafeCapacityForAnAlreadyScaledPattern() {
+        TestPattern basePattern = pattern(2L, 2L, 3L);
+        AEItemKey input = itemKey(Items.IRON_INGOT);
+        AlloyFurnaceCountedCraftingAdapter adapter = new AlloyFurnaceCountedCraftingAdapter(
+                new TestProvider(basePattern), () -> true, TARGET);
+
+        List<CountedCraftingCapacity> capacities = adapter.captureCapacity(
+                new ScaledProcessingPattern(basePattern, 4L), prototype(input, 2L), 7L);
+
+        assertEquals(1, capacities.size());
+        CountedCraftingCapacity capacity = capacities.getFirst();
+        assertEquals(TARGET, capacity.target());
+        assertEquals(7L, capacity.logicalCrafts().orElseThrow());
+        assertEquals(7L, capacity.maximumSingleBatch().orElseThrow());
+    }
+
+    @Test
+    void derivesAStableMachineTargetFromTheProviderIdentity() {
+        CountedCraftingTarget target = AlloyFurnaceCountedCraftingAdapter.targetFor(
+                new TestIdentity("useless_mod:provider-position"));
+
+        assertEquals(CountedCraftingTarget.machine(
+                "useless_mod:provider-position", "useless_mod:provider-position"), target);
+    }
+
+    @Test
+    void submitsOneScaledPatternWithoutMutatingTheOriginalPrototype() {
+        TestPattern basePattern = pattern(2L, 2L, 3L);
+        AEItemKey input = itemKey(Items.IRON_INGOT);
+        IPatternDetails alreadyScaled = new ScaledProcessingPattern(basePattern, 4L);
+        TestProvider provider = new TestProvider(basePattern);
+        AlloyFurnaceCountedCraftingAdapter adapter = new AlloyFurnaceCountedCraftingAdapter(
+                provider, () -> true, TARGET);
+        KeyCounter[] prototype = prototype(input, 8L);
+
+        CountedCraftingAdmission admission = adapter.prepareBatchForTarget(
+                alreadyScaled, prototype, 3L, TARGET);
+
+        assertNotNull(admission);
+        assertEquals(3L, admission.count());
+        assertTrue(admission.commit(prototype));
+        assertTrue(admission.hasTransferredInputOwnership());
+        assertEquals(1, provider.pushCalls);
+        ScaledProcessingPattern submittedPattern = assertInstanceOf(
+                ScaledProcessingPattern.class, provider.submittedPattern);
+        assertEquals(12L, submittedPattern.getOperationsPerPush());
+        KeyCounter[] submittedInputs = provider.submittedInputs;
+        assertEquals(24L, submittedInputs[0].get(input));
+        assertEquals(8L, prototype[0].get(input));
+        assertThrows(IllegalStateException.class, () -> admission.commit(prototype));
+        assertEquals(1, provider.pushCalls);
+    }
+
+    @Test
+    void limitsTheBatchBeforeInputOutputOrMultiplierOverflow() {
+        AEItemKey input = itemKey(Items.IRON_INGOT);
+
+        long maximum = AlloyFurnaceCountedCraftingAdapter.maximumBatchCount(
+                pattern(1L, 1L, 1L), prototype(input, Long.MAX_VALUE), 2L);
+
+        assertEquals(1L, maximum);
+        assertEquals(1L, AlloyFurnaceCountedCraftingAdapter.maximumBatchCount(
+                pattern(Long.MAX_VALUE, 1L, 1L), prototype(input, 1L), 2L));
+        assertEquals(1L, AlloyFurnaceCountedCraftingAdapter.maximumBatchCount(
+                pattern(1L, 1L, Long.MAX_VALUE), prototype(input, 1L), 2L));
+        assertEquals(1L, AlloyFurnaceCountedCraftingAdapter.maximumBatchCount(
+                new ScaledProcessingPattern(pattern(1L, 1L, 1L), Long.MAX_VALUE),
+                prototype(input, 1L), 2L));
+    }
+
+    @Test
+    void rejectsOfflineMissingAndWrongTargetSubmissionsBeforeDispatch() {
+        TestPattern pattern = pattern(1L, 1L, 1L);
+        AEItemKey input = itemKey(Items.IRON_INGOT);
+        KeyCounter[] prototype = prototype(input, 1L);
+        TestProvider onlineProvider = new TestProvider(pattern);
+        AlloyFurnaceCountedCraftingAdapter offlineAdapter = new AlloyFurnaceCountedCraftingAdapter(
+                onlineProvider, () -> false, TARGET);
+
+        assertTrue(offlineAdapter.captureCapacity(pattern, prototype, 1L).isEmpty());
+        assertNull(offlineAdapter.prepareBatch(pattern, prototype, 1L));
+        assertEquals(0, onlineProvider.pushCalls);
+
+        AlloyFurnaceCountedCraftingAdapter missingPatternAdapter = new AlloyFurnaceCountedCraftingAdapter(
+                new TestProvider(), () -> true, TARGET);
+        assertTrue(missingPatternAdapter.captureCapacity(pattern, prototype, 1L).isEmpty());
+        assertNull(missingPatternAdapter.prepareBatch(pattern, prototype, 1L));
+
+        CountedCraftingTarget wrongTarget = CountedCraftingTarget.machine("other-route", "other-machine");
+        AlloyFurnaceCountedCraftingAdapter onlineAdapter = new AlloyFurnaceCountedCraftingAdapter(
+                onlineProvider, () -> true, TARGET);
+        assertNull(onlineAdapter.prepareBatchForTarget(pattern, prototype, 1L, wrongTarget));
+        assertEquals(0, onlineProvider.pushCalls);
+    }
+
+    @Test
+    void rejectedProviderDoesNotTransferInputOwnership() {
+        TestPattern pattern = pattern(1L, 1L, 1L);
+        AEItemKey input = itemKey(Items.IRON_INGOT);
+        TestProvider provider = new TestProvider(pattern);
+        provider.accept = false;
+        AlloyFurnaceCountedCraftingAdapter adapter = new AlloyFurnaceCountedCraftingAdapter(
+                provider, () -> true, TARGET);
+        KeyCounter[] prototype = prototype(input, 1L);
+
+        CountedCraftingAdmission admission = adapter.prepareBatch(pattern, prototype, 2L);
+
+        assertNotNull(admission);
+        assertFalse(admission.commit(prototype));
+        assertFalse(admission.hasTransferredInputOwnership());
+        assertEquals(1, provider.pushCalls);
+        assertEquals(1L, prototype[0].get(input));
+    }
+
+    private static TestPattern pattern(long inputMultiplier, long possibleInputAmount, long outputAmount) {
+        AEItemKey definition = itemKey(Items.PAPER);
+        AEItemKey input = itemKey(Items.IRON_INGOT);
+        AEItemKey output = itemKey(Items.GOLD_INGOT);
+        return new TestPattern(
+                definition,
+                new IPatternDetails.IInput[]{new TestInput(input, inputMultiplier, possibleInputAmount)},
+                List.of(new GenericStack(output, outputAmount)));
+    }
+
+    private static AEItemKey itemKey(Item item) {
+        AEItemKey key = AEItemKey.of(item);
+        if (key == null) {
+            throw new AssertionError("Registered test item must produce an AE item key");
+        }
+        return key;
+    }
+
+    private static KeyCounter[] prototype(AEKey key, long amount) {
+        KeyCounter counter = new KeyCounter();
+        counter.add(key, amount);
+        return new KeyCounter[]{counter};
+    }
+
+    private static final class TestProvider implements ICraftingProvider {
+        private final List<IPatternDetails> patterns;
+        private boolean accept = true;
+        private int pushCalls;
+        @Nullable
+        private IPatternDetails submittedPattern;
+        private KeyCounter[] submittedInputs = new KeyCounter[0];
+
+        private TestProvider(IPatternDetails... patterns) {
+            this.patterns = List.of(patterns);
+        }
+
+        @Override
+        public List<IPatternDetails> getAvailablePatterns() {
+            return patterns;
+        }
+
+        @Override
+        public boolean pushPattern(IPatternDetails patternDetails, KeyCounter[] inputHolder) {
+            pushCalls++;
+            submittedPattern = patternDetails;
+            submittedInputs = inputHolder;
+            return accept;
+        }
+
+        @Override
+        public boolean isBusy() {
+            return false;
+        }
+    }
+
+    private record TestPattern(
+            AEItemKey definition, IPatternDetails.IInput[] inputs, List<GenericStack> outputs) implements IPatternDetails {
+        @Override
+        public AEItemKey getDefinition() {
+            return definition;
+        }
+
+        @Override
+        public IInput[] getInputs() {
+            return inputs.clone();
+        }
+
+        @Override
+        public List<GenericStack> getOutputs() {
+            return outputs;
+        }
+    }
+
+    private record TestInput(AEKey key, long multiplier, long possibleInputAmount)
+            implements IPatternDetails.IInput {
+        @Override
+        public GenericStack[] getPossibleInputs() {
+            return new GenericStack[]{new GenericStack(key, possibleInputAmount)};
+        }
+
+        @Override
+        public long getMultiplier() {
+            return multiplier;
+        }
+
+        @Override
+        public boolean isValid(AEKey input, Level level) {
+            return key.equals(input);
+        }
+
+        @Override
+        public @Nullable AEKey getRemainingKey(AEKey template) {
+            return null;
+        }
+    }
+
+    private record TestIdentity(String digest) implements PatternProviderIdentity {
+        @Override
+        public int version() {
+            return 1;
+        }
+
+        @Override
+        public @NotNull Optional<ProviderIdentityDescriptor> descriptor() {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/test/java/com/sorrowmist/useless/integration/dataenergistics/provider/UselessDataEnergisticsPatternProviderPluginTest.java
+++ b/src/test/java/com/sorrowmist/useless/integration/dataenergistics/provider/UselessDataEnergisticsPatternProviderPluginTest.java
@@ -3,6 +3,8 @@ package com.sorrowmist.useless.integration.dataenergistics.provider;
 import com.fish_dan_.data_energistics.api.registry.provider.PatternProviderRegistry;
 import com.fish_dan_.data_energistics.api.registry.provider.definition.PatternProviderRegistration;
 import com.fish_dan_.data_energistics.api.registry.provider.definition.ProviderIdentityDescriptor;
+import com.fish_dan_.data_energistics.api.registry.search.TrinityPatternSearchRegistry;
+import com.fish_dan_.data_energistics.api.registry.search.TrinityPatternSearchTermRegistration;
 import com.sorrowmist.useless.UselessMod;
 import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.NotNull;
@@ -53,11 +55,32 @@ class UselessDataEnergisticsPatternProviderPluginTest {
         assertNotNull(assembly.postCommitHook());
     }
 
+    @Test
+    void registersTheOmniversalMoldAsASeparateTrinitySearchContributor() {
+        RecordingTrinityPatternSearchRegistry registry = new RecordingTrinityPatternSearchRegistry();
+
+        UselessDataEnergisticsPatternProviderPlugin.registerSearchTerms(registry);
+
+        assertEquals(1, registry.registrations.size());
+        TrinityPatternSearchTermRegistration registration = registry.registrations.getFirst();
+        assertEquals(UselessMod.id("omniversal_pattern_mold_search"), registration.registrationId());
+        assertNotNull(registration.contributor());
+    }
+
     private static final class RecordingPatternProviderRegistry implements PatternProviderRegistry {
         private final List<PatternProviderRegistration> registrations = new ArrayList<>();
 
         @Override
         public void register(@NotNull PatternProviderRegistration registration) {
+            registrations.add(registration);
+        }
+    }
+
+    private static final class RecordingTrinityPatternSearchRegistry implements TrinityPatternSearchRegistry {
+        private final List<TrinityPatternSearchTermRegistration> registrations = new ArrayList<>();
+
+        @Override
+        public void register(@NotNull TrinityPatternSearchTermRegistration registration) {
             registrations.add(registration);
         }
     }

--- a/src/test/java/com/sorrowmist/useless/integration/dataenergistics/provider/UselessDataEnergisticsPatternProviderPluginTest.java
+++ b/src/test/java/com/sorrowmist/useless/integration/dataenergistics/provider/UselessDataEnergisticsPatternProviderPluginTest.java
@@ -1,0 +1,64 @@
+package com.sorrowmist.useless.integration.dataenergistics.provider;
+
+import com.fish_dan_.data_energistics.api.registry.provider.PatternProviderRegistry;
+import com.fish_dan_.data_energistics.api.registry.provider.definition.PatternProviderRegistration;
+import com.fish_dan_.data_energistics.api.registry.provider.definition.ProviderIdentityDescriptor;
+import com.sorrowmist.useless.UselessMod;
+import net.minecraft.resources.ResourceLocation;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class UselessDataEnergisticsPatternProviderPluginTest {
+    @Test
+    void createsAndRegistersBothAlloyFurnaceProviders() {
+        ResourceLocation advancedAlloyFurnaceType = UselessMod.id("test_advanced_alloy_furnace_type");
+        ResourceLocation advancedAlloyFurnaceItem = UselessMod.id("test_advanced_alloy_furnace_item");
+        ResourceLocation mePatternAssemblyType = UselessMod.id("test_me_pattern_assembly_type");
+        ResourceLocation mePatternAssemblyItem = UselessMod.id("test_me_pattern_assembly_item");
+
+        List<PatternProviderRegistration> registrations =
+                UselessDataEnergisticsPatternProviderPlugin.createRegistrations(
+                        advancedAlloyFurnaceType,
+                        advancedAlloyFurnaceItem,
+                        mePatternAssemblyType,
+                        mePatternAssemblyItem);
+        RecordingPatternProviderRegistry registry = new RecordingPatternProviderRegistry();
+        UselessDataEnergisticsPatternProviderPlugin.registerAll(registry, registrations);
+
+        assertEquals(2, registry.registrations.size());
+        PatternProviderRegistration advanced = registry.registrations.getFirst();
+        assertEquals(UselessMod.id("advanced_alloy_furnace"), advanced.metadata().registrationId());
+        assertEquals(new ProviderIdentityDescriptor.Block(advancedAlloyFurnaceType),
+                advanced.metadata().providerIdentity());
+        assertEquals(List.of(UselessMod.id("advanced_alloy_furnace")),
+                advanced.metadata().recipeCategoryIds());
+        assertEquals(List.of(advancedAlloyFurnaceItem), advanced.metadata().workstationItemIds());
+        assertNotNull(advanced.factory());
+        assertNotNull(advanced.postCommitHook());
+
+        PatternProviderRegistration assembly = registry.registrations.get(1);
+        assertEquals(UselessMod.id("me_pattern_assembly"), assembly.metadata().registrationId());
+        assertEquals(new ProviderIdentityDescriptor.Block(mePatternAssemblyType),
+                assembly.metadata().providerIdentity());
+        assertEquals(List.of(UselessMod.id("advanced_alloy_furnace")),
+                assembly.metadata().recipeCategoryIds());
+        assertEquals(List.of(mePatternAssemblyItem), assembly.metadata().workstationItemIds());
+        assertNotNull(assembly.factory());
+        assertNotNull(assembly.postCommitHook());
+    }
+
+    private static final class RecordingPatternProviderRegistry implements PatternProviderRegistry {
+        private final List<PatternProviderRegistration> registrations = new ArrayList<>();
+
+        @Override
+        public void register(@NotNull PatternProviderRegistration registration) {
+            registrations.add(registration);
+        }
+    }
+}

--- a/src/test/java/com/sorrowmist/useless/integration/dataenergistics/search/OmniversalPatternMoldSearchTermsTest.java
+++ b/src/test/java/com/sorrowmist/useless/integration/dataenergistics/search/OmniversalPatternMoldSearchTermsTest.java
@@ -1,0 +1,63 @@
+package com.sorrowmist.useless.integration.dataenergistics.search;
+
+import appeng.api.stacks.AEItemKey;
+
+import com.sorrowmist.useless.core.component.OmniversalPatternData;
+import com.sorrowmist.useless.integration.dataenergistics.DataEnergisticsIntegrationTestBootstrap;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.Items;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class OmniversalPatternMoldSearchTermsTest {
+
+    @BeforeAll
+    static void bootstrapMinecraft() {
+        DataEnergisticsIntegrationTestBootstrap.initialize();
+    }
+
+    @Test
+    void exposesTheStoredMoldAsAnIndependentSearchCandidate() {
+        OmniversalPatternData ironMold = data(itemKey(Items.IRON_INGOT), true);
+        OmniversalPatternData goldMold = data(itemKey(Items.GOLD_INGOT), true);
+
+        List<String> ironTerms = OmniversalPatternMoldSearchTerms.searchTerms(ironMold);
+        List<String> goldTerms = OmniversalPatternMoldSearchTerms.searchTerms(goldMold);
+
+        assertEquals(List.of(itemKey(Items.IRON_INGOT).getDisplayName().getString()), ironTerms);
+        assertEquals(List.of(itemKey(Items.GOLD_INGOT).getDisplayName().getString()), goldTerms);
+        assertNotEquals(ironTerms, goldTerms);
+    }
+
+    @Test
+    void ignoresPatternsThatDoNotNeedAMold() {
+        assertEquals(
+                List.of(),
+                OmniversalPatternMoldSearchTerms.searchTerms(data(itemKey(Items.IRON_INGOT), false)));
+    }
+
+    private static OmniversalPatternData data(AEItemKey mold, boolean requiresMold) {
+        return new OmniversalPatternData(
+                OmniversalPatternData.CURRENT_VERSION,
+                ResourceLocation.fromNamespaceAndPath("useless_mod_test", "molded_alloy"),
+                "fingerprint",
+                requiresMold,
+                Optional.of(mold),
+                List.of(),
+                List.of());
+    }
+
+    private static AEItemKey itemKey(Item item) {
+        return Objects.requireNonNull(AEItemKey.of(item));
+    }
+}


### PR DESCRIPTION
内容：升级 Data Energistics 至 3.0.2 并适配重组器配方 API；通过无参数 @DataEnergisticsEntrypoint 注册高级合金炉和 ME 样板总成的 Trinity 计数批量 Provider；补充直接单元测试。验证：compileJava 与 compileTestJava 已通过；聚焦 JUnit 在测试运行时下载 KotlinForForge 5.11.0 时遇到 SSL connection reset，未改动代理配置。配套 DataEnergistics PR：https://github.com/fish1145/DataEnergistics/pull/189 。发布约束：两个 PR 应同步发布，以避免重复 Provider Identity。